### PR TITLE
Rename all 'pkcs8' to 'PrivateKeyInfo'

### DIFF
--- a/src/tpm2-provider-encoder.c
+++ b/src/tpm2-provider-encoder.c
@@ -113,27 +113,27 @@ typedef int (*tpm2_tss_encode_fun)(TPM2_ENCODER_CTX *, BIO *, TPM2_PKEY *);
 /* TSS2 PRIVATE KEY encoders */
 
 static int
-tpm2_tss_encode_private_pkcs8_der(TPM2_ENCODER_CTX *ectx, BIO *bout, TPM2_PKEY *pkey)
+tpm2_tss_encode_private_PrivateKeyInfo_der(TPM2_ENCODER_CTX *ectx, BIO *bout, TPM2_PKEY *pkey)
 {
     return tpm2_keydata_write(&pkey->data, bout, KEY_FORMAT_DER);
 }
 
-#define tpm2_tss_encode_public_pkcs8_der NO_ENCODE
-#define tpm2_tss_encode_parameters_pkcs8_der NO_ENCODE
+#define tpm2_tss_encode_public_PrivateKeyInfo_der NO_ENCODE
+#define tpm2_tss_encode_parameters_PrivateKeyInfo_der NO_ENCODE
 
-DECLARE_ENCODER(tss, pkcs8, der)
+DECLARE_ENCODER(tss, PrivateKeyInfo, der)
 
 
 static int
-tpm2_tss_encode_private_pkcs8_pem(TPM2_ENCODER_CTX *ectx, BIO *bout, TPM2_PKEY *pkey)
+tpm2_tss_encode_private_PrivateKeyInfo_pem(TPM2_ENCODER_CTX *ectx, BIO *bout, TPM2_PKEY *pkey)
 {
     return tpm2_keydata_write(&pkey->data, bout, KEY_FORMAT_PEM);
 }
 
-#define tpm2_tss_encode_public_pkcs8_pem NO_ENCODE
-#define tpm2_tss_encode_parameters_pkcs8_pem NO_ENCODE
+#define tpm2_tss_encode_public_PrivateKeyInfo_pem NO_ENCODE
+#define tpm2_tss_encode_parameters_PrivateKeyInfo_pem NO_ENCODE
 
-DECLARE_ENCODER(tss, pkcs8, pem)
+DECLARE_ENCODER(tss, PrivateKeyInfo, pem)
 
 
 /* RSA PUBLIC KEY encoders */

--- a/src/tpm2-provider.c
+++ b/src/tpm2-provider.c
@@ -183,8 +183,8 @@ static const OSSL_ALGORITHM tpm2_asymciphers[] = {
     { NULL, NULL, NULL }
 };
 
-extern const OSSL_DISPATCH tpm2_tss_encoder_pkcs8_der_functions[];
-extern const OSSL_DISPATCH tpm2_tss_encoder_pkcs8_pem_functions[];
+extern const OSSL_DISPATCH tpm2_tss_encoder_PrivateKeyInfo_der_functions[];
+extern const OSSL_DISPATCH tpm2_tss_encoder_PrivateKeyInfo_pem_functions[];
 extern const OSSL_DISPATCH tpm2_rsa_encoder_pkcs1_der_functions[];
 extern const OSSL_DISPATCH tpm2_rsa_encoder_pkcs1_pem_functions[];
 extern const OSSL_DISPATCH tpm2_rsa_encoder_SubjectPublicKeyInfo_der_functions[];
@@ -198,12 +198,12 @@ extern const OSSL_DISPATCH tpm2_ec_encoder_text_functions[];
 
 static const OSSL_ALGORITHM tpm2_encoders[] = {
     /* private key */
-    { "RSA", "provider=tpm2,output=der,structure=pkcs8", tpm2_tss_encoder_pkcs8_der_functions },
-    { "RSA", "provider=tpm2,output=pem,structure=pkcs8", tpm2_tss_encoder_pkcs8_pem_functions },
-    { "RSA-PSS", "provider=tpm2,output=der,structure=pkcs8", tpm2_tss_encoder_pkcs8_der_functions },
-    { "RSA-PSS", "provider=tpm2,output=pem,structure=pkcs8", tpm2_tss_encoder_pkcs8_pem_functions },
-    { "EC", "provider=tpm2,output=der,structure=pkcs8", tpm2_tss_encoder_pkcs8_der_functions },
-    { "EC", "provider=tpm2,output=pem,structure=pkcs8", tpm2_tss_encoder_pkcs8_pem_functions },
+    { "RSA", "provider=tpm2,output=der,structure=PrivateKeyInfo", tpm2_tss_encoder_PrivateKeyInfo_der_functions },
+    { "RSA", "provider=tpm2,output=pem,structure=PrivateKeyInfo", tpm2_tss_encoder_PrivateKeyInfo_pem_functions },
+    { "RSA-PSS", "provider=tpm2,output=der,structure=PrivateKeyInfo", tpm2_tss_encoder_PrivateKeyInfo_der_functions },
+    { "RSA-PSS", "provider=tpm2,output=pem,structure=PrivateKeyInfo", tpm2_tss_encoder_PrivateKeyInfo_pem_functions },
+    { "EC", "provider=tpm2,output=der,structure=PrivateKeyInfo", tpm2_tss_encoder_PrivateKeyInfo_der_functions },
+    { "EC", "provider=tpm2,output=pem,structure=PrivateKeyInfo", tpm2_tss_encoder_PrivateKeyInfo_pem_functions },
     /* public key */
     { "RSA", "provider=tpm2,output=der,structure=pkcs1", tpm2_rsa_encoder_pkcs1_der_functions },
     { "RSA", "provider=tpm2,output=pem,structure=pkcs1", tpm2_rsa_encoder_pkcs1_pem_functions },


### PR DESCRIPTION
OpenSSL changed the structure name 'pkcs8' for encoders and decoders
to 'PrivateKeyInfo', the latter being the actual structure name.
(the reason for the name change is a bit more elaborate, please see
the OpenSSL commit log for details)

Signed-off-by: Richard Levitte <richard@levitte.org>