### PR TITLE
When testing ciphers, ensure the algorithm is locally supported

### DIFF
--- a/test/cipher_aes128_cbc.sh
+++ b/test/cipher_aes128_cbc.sh
@@ -3,6 +3,8 @@
 set -eufx
 # skip when the command is not supported
 tpm2_getcap commands | grep EncryptDecrypt || exit 77
+# skip when the algorithm is not supported
+tpm2_getcap algorithms | grep ^aes: || exit 77
 
 echo -n "abcde12345abcde12345" > testdata
 

--- a/test/cipher_aes128_ecb.sh
+++ b/test/cipher_aes128_ecb.sh
@@ -3,6 +3,8 @@
 set -eufx
 # skip when the command is not supported
 tpm2_getcap commands | grep EncryptDecrypt || exit 77
+# skip when the algorithm is not supported
+tpm2_getcap algorithms | grep ^aes: || exit 77
 
 echo -n "abcde12345abcde12345" > testdata
 

--- a/test/cipher_aes256.sh
+++ b/test/cipher_aes256.sh
@@ -3,6 +3,8 @@
 set -eufx
 # skip when the command is not supported
 tpm2_getcap commands | grep EncryptDecrypt || exit 77
+# skip when the algorithm is not supported
+tpm2_getcap algorithms | grep ^aes: || exit 77
 
 echo -n "abcde12345abcde12345" > testdata
 

--- a/test/cipher_aes256_nopad.sh
+++ b/test/cipher_aes256_nopad.sh
@@ -3,6 +3,8 @@
 set -eufx
 # skip when the command is not supported
 tpm2_getcap commands | grep EncryptDecrypt || exit 77
+# skip when the algorithm is not supported
+tpm2_getcap algorithms | grep ^aes: || exit 77
 
 # must be 32 characters
 echo -n "abcde12345abcde12345abcde12345ab" > testdata

--- a/test/cipher_camellia128.sh
+++ b/test/cipher_camellia128.sh
@@ -3,6 +3,8 @@
 set -eufx
 # skip when the command is not supported
 tpm2_getcap commands | grep EncryptDecrypt || exit 77
+# skip when the algorithm is not supported
+tpm2_getcap algorithms | grep ^camellia: || exit 77
 
 echo -n "abcde12345abcde12345" > testdata
 


### PR DESCRIPTION
Skip the particular test if the algorithm isn't supported.

Signed-off-by: Richard Levitte <richard@levitte.org>