### PR TITLE
Fix the TSS2 decoder

### DIFF
--- a/src/tpm2-provider-decoder-tss2.c
+++ b/src/tpm2-provider-decoder-tss2.c
@@ -158,7 +158,7 @@ tpm2_tss2_decoder_decode(void *ctx, OSSL_CORE_BIO *cin, int selection,
     pkey->capability = dctx->capability;
     pkey->object = ESYS_TR_NONE;
 
-    if ((selection & OSSL_KEYMGMT_SELECT_ALL) != 0)
+    if (selection == 0 || (selection & OSSL_KEYMGMT_SELECT_ALL) != 0)
         keytype = decode_privkey(dctx, pkey, bin, pw_cb, pw_cbarg);
 
     if (keytype != NULL) {

--- a/src/tpm2-provider-decoder-tss2.c
+++ b/src/tpm2-provider-decoder-tss2.c
@@ -161,23 +161,6 @@ tpm2_tss2_decoder_decode(void *ctx, OSSL_CORE_BIO *cin, int selection,
     if ((selection & OSSL_KEYMGMT_SELECT_ALL) != 0)
         keytype = decode_privkey(dctx, pkey, bin, pw_cb, pw_cbarg);
 
-    if (keytype == NULL && (selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0) {
-        EC_GROUP *group = NULL;
-
-        /* rewind back */
-        if (BIO_seek(bin, fpos) == -1)
-            goto error2;
-
-        if (d2i_ECPKParameters_bio(bin, &group)) {
-            if ((TPM2_PKEY_EC_CURVE(pkey) = tpm2_nid_to_ecc_curve(
-                        EC_GROUP_get_curve_name(group))) != TPM2_ECC_NONE) {
-                pkey->data.pub.publicArea.type = TPM2_ALG_ECC;
-                keytype = "EC";
-            }
-            EC_GROUP_free(group);
-        }
-    }
-
     if (keytype != NULL) {
         object_type = OSSL_OBJECT_PKEY;
         params[0] = OSSL_PARAM_construct_int(OSSL_OBJECT_PARAM_TYPE, &object_type);

--- a/src/tpm2-provider.c
+++ b/src/tpm2-provider.c
@@ -222,11 +222,13 @@ static const OSSL_ALGORITHM tpm2_encoders[] = {
 };
 
 extern const OSSL_DISPATCH tpm2_der_decoder_functions[];
-extern const OSSL_DISPATCH tpm2_tss_decoder_functions[];
+extern const OSSL_DISPATCH tpm2_tss_to_rsa_decoder_functions[];
+extern const OSSL_DISPATCH tpm2_tss_to_ec_decoder_functions[];
 
 static const OSSL_ALGORITHM tpm2_decoders[] = {
     { "DER", "provider=tpm2,input=pem", tpm2_der_decoder_functions },
-    { "RSA:rsaEncryption", "provider=tpm2,input=der,structure=TSS2", tpm2_tss_decoder_functions },
+    { "RSA:rsaEncryption", "provider=tpm2,input=der,structure=TSS2", tpm2_tss_to_rsa_decoder_functions },
+    { "EC:id-ecPublicKey", "provider=tpm2,input=der,structure=TSS2", tpm2_tss_to_ec_decoder_functions },
     { NULL, NULL, NULL }
 };
 

--- a/test/ec_pki/ec_pki.sh
+++ b/test/ec_pki/ec_pki.sh
@@ -22,7 +22,10 @@ openssl ecparam -provider tpm2 -name $CURVE -genkey -out testdb/root/private/roo
 chmod 600 testdb/root/private/root.key.pem
 
 # Create a Self Signed Root Certificate
-openssl req -provider tpm2 -config $PKIDIR/openssl.cnf -key testdb/root/private/root.key.pem -new \
+# We must use the default provider because testdb/root/private/root.key.pem
+# contains more than a TSS2 object
+openssl req -provider tpm2 -provider default -config $PKIDIR/openssl.cnf -new \
+            -key testdb/root/private/root.key.pem \
             -extensions ext_root -out testdb/root/certs/root.cert.pem -x509 -days 3650 \
             -subj '/C=US/ST=Michigan/O=WanderWriter/OU=WanderWriter Certificate Authority/CN=WanderWriter Root CA'
 
@@ -34,7 +37,10 @@ openssl ecparam -provider tpm2 -name $CURVE -genkey -out testdb/intermediate/pri
 chmod 600 testdb/intermediate/private/intermediate.key.pem
 
 # Create an Intermediary CSR
-openssl req -provider tpm2 -config $PKIDIR/openssl.cnf -new -key testdb/intermediate/private/intermediate.key.pem \
+# We must use the default provider because testdb/root/private/root.key.pem
+# contains more than a TSS2 object
+openssl req -provider tpm2 -provider default -config $PKIDIR/openssl.cnf -new \
+            -key testdb/intermediate/private/intermediate.key.pem \
             -out testdb/intermediate/csr/intermediate.csr.pem \
             -subj '/C=US/ST=Michigan/O=WanderWriter/OU=WanderWriter Certificate Authority/CN=WanderWriter Intermediate CA'
 
@@ -56,7 +62,9 @@ openssl ecparam -provider tpm2 -name $CURVE -genkey -out testdb/client/private/a
 chmod 400 testdb/client/private/agd.key.pem
 
 # Create a Client CSR
-openssl req -provider tpm2 -config $PKIDIR/openssl.cnf -new \
+# We must use the default provider because testdb/root/private/root.key.pem
+# contains more than a TSS2 object
+openssl req -provider tpm2 -provider default -config $PKIDIR/openssl.cnf -new \
             -key testdb/client/private/agd.key.pem -out testdb/client/csr/agd.csr.pem \
             -subj '/C=US/ST=Michigan/O=WanderWriter/OU=Andrew G. Dunn/CN=agd@wanderwriter.ink'
 


### PR DESCRIPTION
It was doing a little too much (decoded EC PARAMETERS?), didn't have the necessary separation between decoders producing different key types, and didn't account for `selection == 0`