### PR TITLE
Fix 'openssl ca' check in test/rsa_pki/rsa_pki.sh and test/ec_pki/ec_pki.sh

### DIFF
--- a/test/ec_pki/ec_pki.sh
+++ b/test/ec_pki/ec_pki.sh
@@ -49,6 +49,11 @@ openssl ca -provider tpm2 -provider base -config $PKIDIR/openssl.cnf -batch -nam
            -extensions ext_intermediate -notext -in testdb/intermediate/csr/intermediate.csr.pem \
            -out testdb/intermediate/certs/intermediate.cert.pem
 
+# Unfortunately, 'openssl ca' doesn't signal certification errors with its
+# exit code, so we must check for the file.
+# The test's exit code is good enough
+[ -f testdb/intermediate/certs/intermediate.cert.pem ]
+
 # Verify Intermediary CA Certificate
 openssl x509 -noout -text -in testdb/intermediate/certs/intermediate.cert.pem
 openssl verify -CAfile testdb/root/certs/root.cert.pem testdb/intermediate/certs/intermediate.cert.pem
@@ -71,6 +76,12 @@ openssl req -provider tpm2 -provider default -config $PKIDIR/openssl.cnf -new \
 # Sign Client Certifcate with Intermediary Certificate
 openssl ca -provider tpm2 -provider base -config $PKIDIR/openssl.cnf -batch -extensions ext_client -notext \
            -in testdb/client/csr/agd.csr.pem -out testdb/client/certs/agd.cert.pem
+
+# Unfortunately, 'openssl ca' doesn't signal certification errors with its
+# exit code, so we must check for the file.
+# The test's exit code is good enough
+[ -f testdb/client/certs/agd.cert.pem ]
+
 chmod 444 testdb/client/certs/agd.cert.pem
 
 # Verify Client Certificate

--- a/test/rsa_pki/rsa_pki.sh
+++ b/test/rsa_pki/rsa_pki.sh
@@ -39,6 +39,10 @@ openssl ca \
     -out testdb/ca/root-ca.crt \
     -extensions root_ca_ext
 
+# Unfortunately, 'openssl ca' doesn't signal certification errors with its
+# exit code, so we must check for the file.
+# The test's exit code is good enough
+[ -f testdb/ca/root-ca.crt ]
 
 # 2. Create Signing CA
 
@@ -70,6 +74,10 @@ openssl ca \
     -out testdb/ca/signing-ca.crt \
     -extensions signing_ca_ext
 
+# Unfortunately, 'openssl ca' doesn't signal certification errors with its
+# exit code, so we must check for the file.
+# The test's exit code is good enough
+[ -f testdb/ca/signing-ca.crt ]
 
 # 3. Operate Signing CA
 
@@ -90,6 +98,11 @@ openssl ca \
     -out testdb/certs/fred.crt \
     -extensions email_ext
 
+# Unfortunately, 'openssl ca' doesn't signal certification errors with its
+# exit code, so we must check for the file.
+# The test's exit code is good enough
+[ -f testdb/ca/fred.crt ]
+
 # 3.3 Create TLS server request
 SAN=DNS:www.simple.org \
 openssl req \
@@ -107,6 +120,11 @@ openssl ca \
     -in testdb/certs/simple.org.csr \
     -out testdb/certs/simple.org.crt \
     -extensions server_ext
+
+# Unfortunately, 'openssl ca' doesn't signal certification errors with its
+# exit code, so we must check for the file.
+# The test's exit code is good enough
+[ -f testdb/ca/simple.org.crt ]
 
 # 3.5 Revoke certificate
 openssl ca \


### PR DESCRIPTION
'openssl ca' doesn't show with its exit code if certification went
good or bad.  This affects tests.

Fixed by explicitly checking that the output file exists.

Signed-off-by: Richard Levitte <richard@levitte.org>