### PR TITLE
Drop '-propquery ?provider=tpm2' everywhere

### DIFF
--- a/test/ec_genpkey_tls_server.sh
+++ b/test/ec_genpkey_tls_server.sh
@@ -36,7 +36,7 @@ openssl req -provider tpm2 -x509 -config testcert.conf -new -newkey ec -pkeyopt 
 openssl x509 -text -noout -in testcert.pem
 
 # start SSL server with ECDSA signing
-openssl s_server -provider tpm2 -provider default -propquery ?provider=tpm2 \
+openssl s_server -provider tpm2 -provider default \
                  -accept 4443 -www -key testkey.pem -cert testcert.pem &
 SERVER=$!
 trap "cleanup" EXIT

--- a/test/rsa_genpkey_tls_server.sh
+++ b/test/rsa_genpkey_tls_server.sh
@@ -37,7 +37,7 @@ openssl req -provider tpm2 -x509 -config testcert.conf -out testcert.pem
 openssl x509 -text -noout -in testcert.pem
 
 # start SSL server with RSA-PSS-RSAE signing
-openssl s_server -provider tpm2 -provider default -propquery ?provider=tpm2 \
+openssl s_server -provider tpm2 -provider default \
                  -accept 4443 -www -key testkey.pem -cert testcert.pem &
 SERVER=$!
 trap "cleanup" EXIT

--- a/test/rsa_genpkey_x509_cmp.sh
+++ b/test/rsa_genpkey_x509_cmp.sh
@@ -38,7 +38,7 @@ openssl cmp -port 8080 -srv_secret pass:1234-5678 \
 SERVER=$!
 
 # send CMP Initial Request for certificate deployment
-openssl cmp -provider tpm2 -provider default -propquery ?provider=tpm2,tpm2.digest!=yes \
+openssl cmp -provider tpm2 -provider default -propquery tpm2.digest!=yes \
             -cmd ir -server localhost:8080/pkix/ -recipient "/CN=CMPserver" \
             -secret pass:1234-5678 -newkey test-client-key.pem -subject "/CN=Client" \
             -certout test-my-cert.pem -cacertsout test-my-ca.pem
@@ -66,7 +66,7 @@ openssl cmp -port 8080 -srv_trusted test-ca-cert.pem \
 SERVER=$!
 
 # send CMP Key Update Request
-openssl cmp -provider tpm2 -provider default -propquery ?provider=tpm2,tpm2.digest!=yes \
+openssl cmp -provider tpm2 -provider default -propquery tpm2.digest!=yes \
             -cmd kur -server localhost:8080/pkix/ -srvcert test-server-cert.pem \
             -key test-client-key.pem -cert test-my-cert.pem \
             -newkey test-client-key2.pem -certout test-my-cert2.pem

--- a/test/rsapss_createak_tls_server.sh
+++ b/test/rsapss_createak_tls_server.sh
@@ -49,7 +49,7 @@ openssl req -provider tpm2 -x509 -config testcert.conf -key handle:${HANDLE} -ou
 openssl x509 -text -noout -in testcert.pem
 
 # start SSL server with RSA-PSS-PSS signing
-openssl s_server -provider tpm2 -provider default -propquery ?provider=tpm2 \
+openssl s_server -provider tpm2 -provider default \
                  -accept 4443 -www -key handle:${HANDLE} -cert testcert.pem &
 SERVER=$!
 trap "cleanup" EXIT


### PR DESCRIPTION
It appears not to be necessary any more.

Signed-off-by: Richard Levitte <richard@levitte.org>
