### PR TITLE
ensure_key_loaded: ensure pkey is not NULL

### DIFF
--- a/src/tpm2-provider-signature.c
+++ b/src/tpm2-provider-signature.c
@@ -107,7 +107,7 @@ ensure_key_loaded(TPM2_PKEY *pkey)
     TSS2_RC r;
 
     /* imported public keys are not auto-loaded by keymgmt */
-    if (pkey->object == ESYS_TR_NONE)
+    if (pkey && pkey->object == ESYS_TR_NONE)
     {
         r = Esys_LoadExternal(pkey->esys_ctx,
                               ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,

--- a/test/digest.sh
+++ b/test/digest.sh
@@ -18,4 +18,13 @@ for HASH in sha1 sha256 sha384 sha512; do
     cmp digest1 digest2
 done
 
-rm testdata digest1 digest2
+rm digest1 digest2
+
+# test sign
+openssl genpkey -provider tpm2 -algorithm RSA -pkeyopt bits:2048 -out myrsakey.pem
+
+openssl dgst -provider tpm2 -provider base \
+  -sha256 -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-1 -sign myrsakey.pem \
+  -out testdata.sig testdata
+
+rm testdata myrsakey.pem testdata.sig


### PR DESCRIPTION
Some calls through the openssl dgst commandlet result in
ensure_key_loaded when their is no pkey context. This results in a NULL
pointer dereference.

Example command:
openssl dgst -provider tpm2 -provider base \
  -sha256 -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-1 -sign myrsakey.pem \
  -out sig -passin pass:password data

Fixes: #30

Signed-off-by: William Roberts <william.c.roberts@intel.com>