### PR TITLE
availability: apply the correct order of providers

### DIFF
--- a/docs/certificates.md
+++ b/docs/certificates.md
@@ -11,7 +11,9 @@ commands work as usual.
 
 For example, to generate a new TPM-based key and a self-signed certificate:
 ```
-openssl req -provider tpm2 -provider default -x509 -subj "/C=GB/CN=foo" -keyout testkey.pem -out testcert.pem
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -x509 -subj "/C=GB/CN=foo" -keyout testkey.pem \
+            -out testcert.pem
 ```
 
 Or, to create a Certificate Signing Request (CSR) based on a persistent
@@ -21,7 +23,9 @@ tpm2_createek -G ecc -c ek_ecc.ctx
 tpm2_createak -C ek_ecc.ctx -G ecc -g sha256 -s ecdsa -c ak_ecc.ctx
 tpm2_evictcontrol -c ak_ecc.ctx 0x81000000
 
-openssl req -provider tpm2 -provider default -new -subj "/C=GB/CN=foo" -key handle:0x81000000 -out testcsr.pem
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -new -subj "/C=GB/CN=foo" -key handle:0x81000000 \
+            -out testcsr.pem
 ```
 
 If the key is not associated with any specific algorithm you may define the
@@ -73,13 +77,14 @@ command works as usual.
 
 For example, to sign data do:
 ```
-openssl cms -sign -provider tpm2 -provider default -nodetach -md sha256 \
-            -inkey testkey.pem -signer testcert.pem -in testdata -text -out testdata.sig
+openssl cms -sign -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -nodetach -md sha256 -inkey testkey.pem -signer testcert.pem \
+            -in testdata -text -out testdata.sig
 ```
 
 And to decrypt data do:
 ```
-openssl cms -decrypt -provider tpm2 -provider default \
+openssl cms -decrypt -provider tpm2 -provider default -propquery '?provider=tpm2' \
             -inkey testkey.pem -recip testcert.pem -in testdata.enc -out testdata
 ```
 
@@ -121,13 +126,15 @@ negotiated.
 To start a test server using the key and X.509 certificate created in the
 previous section do:
 ```
-openssl s_server -provider tpm2 -provider default -accept 4443 -www -key testkey.pem -cert testcert.pem
+openssl s_server -provider tpm2 -provider default  -propquery '?provider=tpm2' \
+                 -accept 4443 -www -key testkey.pem -cert testcert.pem
 ```
 
 For a mTLS connection, on client side:
 ```bash
-openssl s_client -provider tpm2 -provider default -connect 192.168.251.2:8443 \
-                 -CAfile ec-cacert.pem -cert client.crt -key handle:0x81000000 -state -debug
+openssl s_client -provider tpm2 -provider default  -propquery '?provider=tpm2' \
+                 -connect 192.168.251.2:8443 -CAfile ec-cacert.pem \
+                 -cert client.crt -key handle:0x81000000 -state -debug
 ```
 
 The `-key` can be also specified using a persistent key handle.

--- a/test/ec_createak_x509_cms.sh
+++ b/test/ec_createak_x509_cms.sh
@@ -25,14 +25,16 @@ commonName          = Common Name
 EOF
 
 # create a private key and then generate a self-signed certificate for it
-openssl req -provider tpm2 -provider default -x509 -config testcert.conf -key handle:${HANDLE} -out testcert.pem
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -x509 -config testcert.conf -key handle:${HANDLE} -out testcert.pem
 
 echo -n "this is some text" > testdata
 
 # sign data, output MIME
 # as the key is restricted to sha256, the -md parameter is not given
-openssl cms -sign -provider tpm2 -provider default -nodetach \
-    -inkey handle:${HANDLE} -signer testcert.pem -in testdata -text -out testdata.sig
+openssl cms -sign -provider tpm2 -provider default  -propquery '?provider=tpm2' \
+            -nodetach -inkey handle:${HANDLE} -signer testcert.pem \
+            -in testdata -text -out testdata.sig
 
 # verify signed data
 openssl cms -verify -in testdata.sig -text -noverify -out testdata2

--- a/test/ec_createak_x509_csr_auth.sh
+++ b/test/ec_createak_x509_csr_auth.sh
@@ -25,8 +25,9 @@ commonName          = Common Name
 EOF
 
 # create a private key and then generate a certificate request from it
-openssl req -provider tpm2 -provider default -new -config testcert.conf \
-    -key handle:${HANDLE}?pass -passin pass:abc -out testcsr.pem
+openssl req -provider tpm2 -provider default  -propquery '?provider=tpm2' \
+            -new -config testcert.conf -key handle:${HANDLE}?pass \
+            -passin pass:abc -out testcsr.pem
 
 # display private key info
 openssl pkey -provider tpm2 -in handle:${HANDLE} -text -noout

--- a/test/ec_createak_x509_index.sh
+++ b/test/ec_createak_x509_index.sh
@@ -25,7 +25,9 @@ commonName          = Common Name
 EOF
 
 # create a private key and then generate a self-signed certificate for it
-openssl req -provider tpm2 -provider default -x509 -config testcert.conf -key handle:${HANDLE} -out testcert.der -outform der
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -x509 -config testcert.conf -key handle:${HANDLE} \
+            -out testcert.der -outform der
 DERSIZE=`ls -l testcert.der | awk '{print $5}'`
 
 # allocate NV index in the TPM

--- a/test/ec_genpkey_tls_server.sh
+++ b/test/ec_genpkey_tls_server.sh
@@ -36,7 +36,7 @@ openssl req -provider tpm2 -provider default -x509 -config testcert.conf -new -n
 openssl x509 -text -noout -in testcert.pem
 
 # start SSL server with ECDSA signing, default port 4433
-openssl s_server -provider tpm2 -provider default \
+openssl s_server -provider tpm2 -provider default -propquery '?provider=tpm2' \
                  -www -key testkey.pem -cert testcert.pem &
 SERVER=$!
 trap "cleanup" EXIT

--- a/test/ec_genpkey_x509_cms.sh
+++ b/test/ec_genpkey_x509_cms.sh
@@ -16,7 +16,8 @@ commonName          = Common Name
 EOF
 
 # create a EC private key and then generate a self-signed certificate for it
-openssl req -provider tpm2 -provider default -x509 -config testcert.conf -new -newkey ec -pkeyopt group:P-256 -out testcert.pem
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -x509 -config testcert.conf -new -newkey ec -pkeyopt group:P-256 -out testcert.pem
 
 # print the certificate
 openssl x509 -in testcert.pem -text
@@ -24,8 +25,9 @@ openssl x509 -in testcert.pem -text
 echo -n "this is some text" > testdata
 
 # sign data, output MIME
-openssl cms -sign -provider tpm2 -provider default -nodetach -md sha256 \
-    -inkey testkey.pem -signer testcert.pem -in testdata -text -out testdata.sig
+openssl cms -sign -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -nodetach -md sha256 -inkey testkey.pem -signer testcert.pem \
+            -in testdata -text -out testdata.sig
 
 # verify signed data
 openssl cms -verify -in testdata.sig -text -noverify -out testdata2
@@ -37,7 +39,7 @@ cmp testdata testdata2
 openssl cms -encrypt -aes256 -recip testcert.pem -in testdata -out testdata.enc
 
 # decrypt data
-openssl cms -decrypt -provider tpm2 -provider default \
+openssl cms -decrypt -provider tpm2 -provider default -propquery '?provider=tpm2' \
     -inkey testkey.pem -recip testcert.pem -in testdata.enc -out testdata3
 
 # compare the results

--- a/test/ec_pki/ec_pki.sh
+++ b/test/ec_pki/ec_pki.sh
@@ -24,7 +24,8 @@ chmod 600 testdb/root/private/root.key.pem
 # Create a Self Signed Root Certificate
 # We must use the default provider because testdb/root/private/root.key.pem
 # contains more than a TSS2 object
-openssl req -provider tpm2 -provider default -config $PKIDIR/openssl.cnf -new \
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -config $PKIDIR/openssl.cnf -new \
             -key testdb/root/private/root.key.pem \
             -extensions ext_root -out testdb/root/certs/root.cert.pem -x509 -days 3650 \
             -subj '/C=US/ST=Michigan/O=WanderWriter/OU=WanderWriter Certificate Authority/CN=WanderWriter Root CA'
@@ -39,13 +40,15 @@ chmod 600 testdb/intermediate/private/intermediate.key.pem
 # Create an Intermediary CSR
 # We must use the default provider because testdb/root/private/root.key.pem
 # contains more than a TSS2 object
-openssl req -provider tpm2 -provider default -config $PKIDIR/openssl.cnf -new \
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -config $PKIDIR/openssl.cnf -new \
             -key testdb/intermediate/private/intermediate.key.pem \
             -out testdb/intermediate/csr/intermediate.csr.pem \
             -subj '/C=US/ST=Michigan/O=WanderWriter/OU=WanderWriter Certificate Authority/CN=WanderWriter Intermediate CA'
 
 # Sign Intermediary CA Certificate with Root Certificate
-openssl ca -provider tpm2 -provider default -config $PKIDIR/openssl.cnf -batch -name ca_root \
+openssl ca -provider tpm2 -provider default -propquery '?provider=tpm2' \
+           -config $PKIDIR/openssl.cnf -batch -name ca_root \
            -extensions ext_intermediate -notext -in testdb/intermediate/csr/intermediate.csr.pem \
            -out testdb/intermediate/certs/intermediate.cert.pem
 
@@ -69,12 +72,14 @@ chmod 400 testdb/client/private/agd.key.pem
 # Create a Client CSR
 # We must use the default provider because testdb/root/private/root.key.pem
 # contains more than a TSS2 object
-openssl req -provider tpm2 -provider default -config $PKIDIR/openssl.cnf -new \
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -config $PKIDIR/openssl.cnf -new \
             -key testdb/client/private/agd.key.pem -out testdb/client/csr/agd.csr.pem \
             -subj '/C=US/ST=Michigan/O=WanderWriter/OU=Andrew G. Dunn/CN=agd@wanderwriter.ink'
 
 # Sign Client Certifcate with Intermediary Certificate
-openssl ca -provider tpm2 -provider default -config $PKIDIR/openssl.cnf -batch -extensions ext_client -notext \
+openssl ca -provider tpm2 -provider default -propquery '?provider=tpm2' \
+           -config $PKIDIR/openssl.cnf -batch -extensions ext_client -notext \
            -in testdb/client/csr/agd.csr.pem -out testdb/client/certs/agd.cert.pem
 
 # Unfortunately, 'openssl ca' doesn't signal certification errors with its
@@ -92,7 +97,8 @@ openssl verify -CAfile testdb/intermediate/certs/chain.cert.pem testdb/client/ce
 # (not supported)
 
 # Generate a CRL
-openssl ca -provider tpm2 -provider default -config $PKIDIR/openssl.cnf -gencrl \
+openssl ca -provider tpm2 -provider default -propquery '?provider=tpm2' \
+           -config $PKIDIR/openssl.cnf -gencrl \
            -out testdb/intermediate/crl/intermediate.crl.pem -crldays 365
 
 # Verify CRL

--- a/test/rsa_createak_x509_csr.sh
+++ b/test/rsa_createak_x509_csr.sh
@@ -25,7 +25,8 @@ commonName          = Common Name
 EOF
 
 # create a private key and then generate a certificate request from it
-openssl req -provider tpm2 -provider default -new -config testcert.conf -key handle:${HANDLE} -out testcsr.pem
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -new -config testcert.conf -key handle:${HANDLE} -out testcsr.pem
 
 # display private key info
 openssl rsa -provider tpm2 -in handle:${HANDLE} -text -noout

--- a/test/rsa_genpkey_tls_server.sh
+++ b/test/rsa_genpkey_tls_server.sh
@@ -31,13 +31,14 @@ DNS.1               = localhost
 EOF
 
 # create a RSAE private key and then generate a self-signed certificate for it
-openssl req -provider tpm2 -provider default -x509 -config testcert.conf -out testcert.pem
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -x509 -config testcert.conf -out testcert.pem
 
 # display content of the certificate
 openssl x509 -text -noout -in testcert.pem
 
 # start SSL server with RSA-PSS-RSAE signing, port 4431
-openssl s_server -provider tpm2 -provider default \
+openssl s_server -provider tpm2 -provider default -propquery '?provider=tpm2' \
                  -accept 4431 -www -key testkey.pem -cert testcert.pem &
 SERVER=$!
 trap "cleanup" EXIT

--- a/test/rsa_genpkey_x509_cert.sh
+++ b/test/rsa_genpkey_x509_cert.sh
@@ -17,7 +17,8 @@ commonName          = Common Name
 EOF
 
 # create a private key and then generate a self-signed certificate for it
-openssl req -provider tpm2 -provider default -x509 -sigopt pad-mode:pss -config testcert.conf -out testcert.pem
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -x509 -sigopt pad-mode:pss -config testcert.conf -out testcert.pem
 
 # display private key info
 openssl rsa -provider tpm2 -provider base -in testkey.pem -text -noout

--- a/test/rsa_genpkey_x509_cmp.sh
+++ b/test/rsa_genpkey_x509_cmp.sh
@@ -20,9 +20,9 @@ openssl genrsa -out test-server-key.pem 2048
 
 # We use the default provider here, to get the default RSA keymgmt to handle
 # the perfectly normal public RSA key to be found in test-ca-cert.pem
-openssl req -provider tpm2 -provider default -x509 -sha256 -nodes \
-            -subj "/C=GB/CN=server.example.com" -extensions usr_cert \
-            -CAkey test-ca-key.pem -CA test-ca-cert.pem \
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -x509 -sha256 -nodes -subj "/C=GB/CN=server.example.com" \
+            -extensions usr_cert -CAkey test-ca-key.pem -CA test-ca-cert.pem \
             -key test-server-key.pem -out test-server-cert.pem
 
 openssl x509 -in test-server-cert.pem -noout -text
@@ -30,7 +30,8 @@ openssl x509 -in test-server-cert.pem -noout -text
 # create client key and certificate, signed by the root CA
 # We use the default provider here, to get the default RSA keymgmt to handle
 # the perfectly normal RSA key to be found in test-ca-cert.pem
-openssl req -provider tpm2 -provider default -x509 -newkey rsa:2048 -sha256 -nodes \
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -x509 -newkey rsa:2048 -sha256 -nodes \
             -subj "/C=GB/CN=client.example.com" -extensions usr_cert \
             -CAkey test-ca-key.pem -CA test-ca-cert.pem \
             -keyout test-client-key.pem -out test-client-cert.pem
@@ -60,7 +61,8 @@ cmp test-my-ca.pem test-ca-cert.pem
 # create another client key and certificate, signed by the root CA
 # We use the default provider here, to get the default RSA keymgmt to handle
 # the perfectly normal RSA key to be found in test-ca-cert.pem
-openssl req -provider tpm2 -provider default -x509 -newkey rsa:2048 -sha256 -nodes \
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -x509 -newkey rsa:2048 -sha256 -nodes \
             -subj "/C=GB/CN=client.example.com" -extensions usr_cert \
             -CAkey test-ca-key.pem -CA test-ca-cert.pem \
             -keyout test-client-key2.pem -out test-client-cert2.pem

--- a/test/rsa_genpkey_x509_cms.sh
+++ b/test/rsa_genpkey_x509_cms.sh
@@ -17,13 +17,15 @@ commonName          = Common Name
 EOF
 
 # create a private key and then generate a self-signed certificate for it
-openssl req -provider tpm2 -provider default -x509 -sigopt pad-mode:pss -config testcert.conf -out testcert.pem
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -x509 -sigopt pad-mode:pss -config testcert.conf -out testcert.pem
 
 echo -n "this is some text" > testdata
 
 # sign data, output MIME
-openssl cms -sign -provider tpm2 -provider default -nodetach -md sha256 \
-    -inkey testkey.pem -signer testcert.pem -in testdata -text -out testdata.sig
+openssl cms -sign -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -nodetach -md sha256 -inkey testkey.pem -signer testcert.pem \
+            -in testdata -text -out testdata.sig
 
 # verify signed data
 openssl cms -verify -in testdata.sig -text -noverify -out testdata2
@@ -35,7 +37,7 @@ cmp testdata testdata2
 openssl cms -encrypt -aes-128-cbc -recip testcert.pem -in testdata -out testdata.enc
 
 # decrypt data
-openssl cms -decrypt -provider tpm2 -provider default \
+openssl cms -decrypt -provider tpm2 -provider default -propquery '?provider=tpm2' \
     -inkey testkey.pem -recip testcert.pem -in testdata.enc -out testdata3
 
 # compare the results

--- a/test/rsa_pki/rsa_pki.sh
+++ b/test/rsa_pki/rsa_pki.sh
@@ -24,6 +24,7 @@ echo 01 > testdb/ca/root-ca/db/root-ca.crl.srl
 # 1.3 Create CA request
 openssl req \
     -provider tpm2 -provider default \
+    -propquery '?provider=tpm2' \
     -new \
     -config $PKIDIR/etc/root-ca.conf \
     -out testdb/ca/root-ca.csr \
@@ -32,6 +33,7 @@ openssl req \
 # 1.4 Create CA certificate
 openssl ca \
     -provider tpm2 -provider default \
+    -propquery '?provider=tpm2' \
     -selfsign \
     -config $PKIDIR/etc/root-ca.conf \
     -batch \
@@ -60,6 +62,7 @@ echo 01 > testdb/ca/signing-ca/db/signing-ca.crl.srl
 # 2.3 Create CA request
 openssl req \
     -provider tpm2 -provider default \
+    -propquery '?provider=tpm2' \
     -new \
     -config $PKIDIR/etc/signing-ca.conf \
     -out testdb/ca/signing-ca.csr \
@@ -68,6 +71,7 @@ openssl req \
 # 2.4 Create CA certificate
 openssl ca \
     -provider tpm2 -provider default \
+    -propquery '?provider=tpm2' \
     -config $PKIDIR/etc/root-ca.conf \
     -batch \
     -in testdb/ca/signing-ca.csr \
@@ -84,6 +88,7 @@ openssl ca \
 # 3.1 Create email request
 openssl req \
     -provider tpm2 -provider default \
+    -propquery '?provider=tpm2' \
     -new \
     -config $PKIDIR/etc/email.conf \
     -out testdb/certs/fred.csr \
@@ -92,6 +97,7 @@ openssl req \
 # 3.2 Create email certificate
 openssl ca \
     -provider tpm2 -provider default \
+    -propquery '?provider=tpm2' \
     -config $PKIDIR/etc/signing-ca.conf \
     -batch \
     -in testdb/certs/fred.csr \
@@ -107,6 +113,7 @@ openssl ca \
 SAN=DNS:www.simple.org \
 openssl req \
     -provider tpm2 -provider default \
+    -propquery '?provider=tpm2' \
     -new \
     -config $PKIDIR/etc/server.conf \
     -out testdb/certs/simple.org.csr \
@@ -115,6 +122,7 @@ openssl req \
 # 3.4 Create TLS server certificate
 openssl ca \
     -provider tpm2 -provider default \
+    -propquery '?provider=tpm2' \
     -config $PKIDIR/etc/signing-ca.conf \
     -batch \
     -in testdb/certs/simple.org.csr \
@@ -129,6 +137,7 @@ openssl ca \
 # 3.5 Revoke certificate
 openssl ca \
     -provider tpm2 -provider default \
+    -propquery '?provider=tpm2' \
     -config $PKIDIR/etc/signing-ca.conf \
     -revoke testdb/ca/signing-ca/01.pem \
     -crl_reason superseded
@@ -136,6 +145,7 @@ openssl ca \
 # 3.6 Create CRL
 openssl ca \
     -provider tpm2 -provider default \
+    -propquery '?provider=tpm2' \
     -gencrl \
     -config $PKIDIR/etc/signing-ca.conf \
     -out testdb/crl/signing-ca.crl

--- a/test/rsapss_createak_tls_server.sh
+++ b/test/rsapss_createak_tls_server.sh
@@ -43,13 +43,14 @@ DNS.1               = localhost
 EOF
 
 # create a private key and then generate a self-signed certificate for it
-openssl req -provider tpm2 -provider default -x509 -config testcert.conf -key handle:${HANDLE} -out testcert.pem
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
+            -x509 -config testcert.conf -key handle:${HANDLE} -out testcert.pem
 
 # display content of the certificate
 openssl x509 -text -noout -in testcert.pem
 
 # start SSL server with RSA-PSS-PSS signing, port 4432
-openssl s_server -provider tpm2 -provider default \
+openssl s_server -provider tpm2 -provider default -propquery '?provider=tpm2' \
                  -accept 4432 -www -key handle:${HANDLE} -cert testcert.pem &
 SERVER=$!
 trap "cleanup" EXIT


### PR DESCRIPTION
Apply the correct order of providers independently of the openssl configuration.

Closes: https://github.com/tpm2-software/tpm2-openssl/issues/63