### PR TITLE
Fix warnings

### DIFF
--- a/src/tpm2-provider-encoder.c
+++ b/src/tpm2-provider-encoder.c
@@ -19,8 +19,8 @@ struct tpm2_encoder_ctx_st {
 };
 
 static OSSL_FUNC_encoder_newctx_fn tpm2_encoder_newctx;
-static OSSL_FUNC_encoder_freectx_fn tpm2_encoder_freectx;
-static OSSL_FUNC_encoder_encode_fn tpm2_encoder_encode_text;
+// static OSSL_FUNC_encoder_freectx_fn tpm2_encoder_freectx;
+// static OSSL_FUNC_encoder_encode_fn tpm2_encoder_encode_text;
 
 static void *
 tpm2_encoder_newctx(void *provctx)

--- a/src/tpm2-provider-encoder.c
+++ b/src/tpm2-provider-encoder.c
@@ -79,14 +79,11 @@ tpm2_encoder_freectx(void *ctx)
         if ((bout = BIO_new_from_core_bio(ectx->libctx, cout)) == NULL) \
             return 0; \
         if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) { \
-            if (tpm2_##otype##_encode_private_##ostructure##_##oformat) \
-                ret = tpm2_##otype##_encode_private_##ostructure##_##oformat(ectx, bout, pkey); \
+            ret = tpm2_##otype##_encode_private_##ostructure##_##oformat(ectx, bout, pkey); \
         } else if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) { \
-            if (tpm2_##otype##_encode_public_##ostructure##_##oformat) \
-                ret = tpm2_##otype##_encode_public_##ostructure##_##oformat(ectx, bout, pkey); \
+            ret = tpm2_##otype##_encode_public_##ostructure##_##oformat(ectx, bout, pkey); \
         } else if (selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) { \
-            if (tpm2_##otype##_encode_parameters_##ostructure##_##oformat) \
-                ret = tpm2_##otype##_encode_parameters_##ostructure##_##oformat(ectx, bout, pkey); \
+            ret = tpm2_##otype##_encode_parameters_##ostructure##_##oformat(ectx, bout, pkey); \
         } \
         BIO_free(bout); \
         return ret; \

--- a/src/tpm2-provider-keymgmt-ec.c
+++ b/src/tpm2-provider-keymgmt-ec.c
@@ -257,7 +257,6 @@ tpm2_ec_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
     free(keyPrivate);
     TPM2_CHECK_RC(gen->core, r, TPM2_ERR_CANNOT_CREATE_KEY, goto error1);
 
-final:
     if (gen->parentHandle && gen->parentHandle != TPM2_RH_OWNER)
         Esys_TR_Close(gen->esys_ctx, &parent);
     else

--- a/src/tpm2-provider-keymgmt-rsa.c
+++ b/src/tpm2-provider-keymgmt-rsa.c
@@ -299,7 +299,6 @@ tpm2_rsa_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
     free(keyPrivate);
     TPM2_CHECK_RC(gen->core, r, TPM2_ERR_CANNOT_CREATE_KEY, goto error1);
 
-final:
     if (gen->parentHandle && gen->parentHandle != TPM2_RH_OWNER)
         Esys_TR_Close(gen->esys_ctx, &parent);
     else

--- a/src/tpm2-provider-pkey.c
+++ b/src/tpm2-provider-pkey.c
@@ -263,7 +263,7 @@ tpm2_load_parent(const OSSL_CORE_HANDLE *core, ESYS_CONTEXT *esys_ctx,
                 TPM2_ERROR_raise(core, TPM2_ERR_WRONG_DATA_LENGTH);
                 goto error1;
             }
-            auth->size = snprintf(auth->buffer, sizeof(auth->buffer),
+            auth->size = snprintf((char*)(auth->buffer), sizeof(auth->buffer),
                     "%s", pauth);
         }
     }

--- a/src/tpm2-provider-x509.c
+++ b/src/tpm2-provider-x509.c
@@ -66,7 +66,7 @@ tpm2_hash_to_x509(TPM2_ALG_ID digalg)
         return NULL;
     if (X509_ALGOR_set0(res, pssoid, V_ASN1_NULL, NULL))
         return res;
-error:
+// error
     X509_ALGOR_free(res);
     return NULL;
 }


### PR DESCRIPTION
This tries to fix <https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=2144589#c2>. Yes, there are several warnings when compiled with Fedora compiler settings.

ToDos

* [ ] The cast in the sprintf might be wrong
* [ ] Removing the static functions might be wrong
* [ ] Removing the ``if (tpm2_##otype##_encode_private_##ostructure##_##oformat)`` might be wrong

What I did:

```
export CFLAGS='-O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer'
./bootstrap
./configure
make clean
make V=1
```

```
make V=1
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider.Tpo -c -o src/tpm2_la-tpm2-provider.lo `test -f 'src/tpm2-provider.c' || echo './'`src/tpm2-provider.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider.Tpo -c src/tpm2-provider.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider.o
mv -f src/.deps/tpm2_la-tpm2-provider.Tpo src/.deps/tpm2_la-tpm2-provider.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-core.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-core.Tpo -c -o src/tpm2_la-tpm2-provider-core.lo `test -f 'src/tpm2-provider-core.c' || echo './'`src/tpm2-provider-core.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-core.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-core.Tpo -c src/tpm2-provider-core.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-core.o
mv -f src/.deps/tpm2_la-tpm2-provider-core.Tpo src/.deps/tpm2_la-tpm2-provider-core.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-types.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-types.Tpo -c -o src/tpm2_la-tpm2-provider-types.lo `test -f 'src/tpm2-provider-types.c' || echo './'`src/tpm2-provider-types.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-types.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-types.Tpo -c src/tpm2-provider-types.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-types.o
mv -f src/.deps/tpm2_la-tpm2-provider-types.Tpo src/.deps/tpm2_la-tpm2-provider-types.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-x509.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-x509.Tpo -c -o src/tpm2_la-tpm2-provider-x509.lo `test -f 'src/tpm2-provider-x509.c' || echo './'`src/tpm2-provider-x509.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-x509.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-x509.Tpo -c src/tpm2-provider-x509.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-x509.o
src/tpm2-provider-x509.c: In function 'tpm2_hash_to_x509':
src/tpm2-provider-x509.c:69:1: warning: label 'error' defined but not used [-Wunused-label]
   69 | error:
      | ^~~~~
mv -f src/.deps/tpm2_la-tpm2-provider-x509.Tpo src/.deps/tpm2_la-tpm2-provider-x509.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-rand.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-rand.Tpo -c -o src/tpm2_la-tpm2-provider-rand.lo `test -f 'src/tpm2-provider-rand.c' || echo './'`src/tpm2-provider-rand.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-rand.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-rand.Tpo -c src/tpm2-provider-rand.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-rand.o
mv -f src/.deps/tpm2_la-tpm2-provider-rand.Tpo src/.deps/tpm2_la-tpm2-provider-rand.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-pkey.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-pkey.Tpo -c -o src/tpm2_la-tpm2-provider-pkey.lo `test -f 'src/tpm2-provider-pkey.c' || echo './'`src/tpm2-provider-pkey.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-pkey.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-pkey.Tpo -c src/tpm2-provider-pkey.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-pkey.o
src/tpm2-provider-pkey.c: In function 'tpm2_load_parent':
src/tpm2-provider-pkey.c:266:39: warning: pointer targets in passing argument 1 of 'snprintf' differ in signedness [-Wpointer-sign]
  266 |             auth->size = snprintf(auth->buffer, sizeof(auth->buffer),
      |                                   ~~~~^~~~~~~~
      |                                       |
      |                                       BYTE * {aka unsigned char *}
In file included from /usr/include/features.h:491,
                 from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/string.h:26,
                 from src/tpm2-provider-pkey.c:3:
/usr/include/bits/stdio2.h:51:1: note: expected 'char * restrict' but argument is of type 'BYTE *' {aka 'unsigned char *'}
   51 | __NTH (snprintf (char *__restrict __s, size_t __n,
      | ^~~~~
mv -f src/.deps/tpm2_la-tpm2-provider-pkey.Tpo src/.deps/tpm2_la-tpm2-provider-pkey.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-store-object.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-store-object.Tpo -c -o src/tpm2_la-tpm2-provider-store-object.lo `test -f 'src/tpm2-provider-store-object.c' || echo './'`src/tpm2-provider-store-object.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-store-object.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-store-object.Tpo -c src/tpm2-provider-store-object.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-store-object.o
mv -f src/.deps/tpm2_la-tpm2-provider-store-object.Tpo src/.deps/tpm2_la-tpm2-provider-store-object.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-decoder-der.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-decoder-der.Tpo -c -o src/tpm2_la-tpm2-provider-decoder-der.lo `test -f 'src/tpm2-provider-decoder-der.c' || echo './'`src/tpm2-provider-decoder-der.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-decoder-der.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-decoder-der.Tpo -c src/tpm2-provider-decoder-der.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-decoder-der.o
mv -f src/.deps/tpm2_la-tpm2-provider-decoder-der.Tpo src/.deps/tpm2_la-tpm2-provider-decoder-der.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-decoder-tss2.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-decoder-tss2.Tpo -c -o src/tpm2_la-tpm2-provider-decoder-tss2.lo `test -f 'src/tpm2-provider-decoder-tss2.c' || echo './'`src/tpm2-provider-decoder-tss2.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-decoder-tss2.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-decoder-tss2.Tpo -c src/tpm2-provider-decoder-tss2.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-decoder-tss2.o
mv -f src/.deps/tpm2_la-tpm2-provider-decoder-tss2.Tpo src/.deps/tpm2_la-tpm2-provider-decoder-tss2.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-encoder.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-encoder.Tpo -c -o src/tpm2_la-tpm2-provider-encoder.lo `test -f 'src/tpm2-provider-encoder.c' || echo './'`src/tpm2-provider-encoder.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-encoder.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-encoder.Tpo -c src/tpm2-provider-encoder.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-encoder.o
src/tpm2-provider-encoder.c: In function 'tpm2_tss_encoder_encode_PrivateKeyInfo_der':
src/tpm2-provider-encoder.c:82:17: warning: the address of 'tpm2_tss_encode_private_PrivateKeyInfo_der' will always evaluate as 'true' [-Waddress]
   82 |             if (tpm2_##otype##_encode_private_##ostructure##_##oformat) \
      |                 ^~~~~
src/tpm2-provider-encoder.c:106:5: note: in expansion of macro 'IMPLEMENT_ENCODER_ENCODE'
  106 |     IMPLEMENT_ENCODER_ENCODE(otype, ostructure, oformat) \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:124:1: note: in expansion of macro 'DECLARE_ENCODER'
  124 | DECLARE_ENCODER(tss, PrivateKeyInfo, der)
      | ^~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c: In function 'tpm2_tss_encoder_encode_PrivateKeyInfo_pem':
src/tpm2-provider-encoder.c:82:17: warning: the address of 'tpm2_tss_encode_private_PrivateKeyInfo_pem' will always evaluate as 'true' [-Waddress]
   82 |             if (tpm2_##otype##_encode_private_##ostructure##_##oformat) \
      |                 ^~~~~
src/tpm2-provider-encoder.c:106:5: note: in expansion of macro 'IMPLEMENT_ENCODER_ENCODE'
  106 |     IMPLEMENT_ENCODER_ENCODE(otype, ostructure, oformat) \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:136:1: note: in expansion of macro 'DECLARE_ENCODER'
  136 | DECLARE_ENCODER(tss, PrivateKeyInfo, pem)
      | ^~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c: In function 'tpm2_rsa_encoder_encode_pkcs1_der':
src/tpm2-provider-encoder.c:85:17: warning: the address of 'tpm2_rsa_encode_public_pkcs1_der' will always evaluate as 'true' [-Waddress]
   85 |             if (tpm2_##otype##_encode_public_##ostructure##_##oformat) \
      |                 ^~~~~
src/tpm2-provider-encoder.c:106:5: note: in expansion of macro 'IMPLEMENT_ENCODER_ENCODE'
  106 |     IMPLEMENT_ENCODER_ENCODE(otype, ostructure, oformat) \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:221:1: note: in expansion of macro 'DECLARE_ENCODER'
  221 | DECLARE_ENCODER(rsa, pkcs1, der)
      | ^~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c: In function 'tpm2_rsa_encoder_encode_pkcs1_pem':
src/tpm2-provider-encoder.c:85:17: warning: the address of 'tpm2_rsa_encode_public_pkcs1_pem' will always evaluate as 'true' [-Waddress]
   85 |             if (tpm2_##otype##_encode_public_##ostructure##_##oformat) \
      |                 ^~~~~
src/tpm2-provider-encoder.c:106:5: note: in expansion of macro 'IMPLEMENT_ENCODER_ENCODE'
  106 |     IMPLEMENT_ENCODER_ENCODE(otype, ostructure, oformat) \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:242:1: note: in expansion of macro 'DECLARE_ENCODER'
  242 | DECLARE_ENCODER(rsa, pkcs1, pem)
      | ^~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c: In function 'tpm2_rsa_encoder_encode_SubjectPublicKeyInfo_der':
src/tpm2-provider-encoder.c:85:17: warning: the address of 'tpm2_rsa_encode_public_SubjectPublicKeyInfo_der' will always evaluate as 'true' [-Waddress]
   85 |             if (tpm2_##otype##_encode_public_##ostructure##_##oformat) \
      |                 ^~~~~
src/tpm2-provider-encoder.c:106:5: note: in expansion of macro 'IMPLEMENT_ENCODER_ENCODE'
  106 |     IMPLEMENT_ENCODER_ENCODE(otype, ostructure, oformat) \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:275:5: note: in expansion of macro 'DECLARE_ENCODER'
  275 |     DECLARE_ENCODER(type, SubjectPublicKeyInfo, der) \
      |     ^~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:307:1: note: in expansion of macro 'DECLARE_ENCODER_X509_PUBKEY'
  307 | DECLARE_ENCODER_X509_PUBKEY(rsa)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c: In function 'tpm2_rsa_encoder_encode_SubjectPublicKeyInfo_pem':
src/tpm2-provider-encoder.c:85:17: warning: the address of 'tpm2_rsa_encode_public_SubjectPublicKeyInfo_pem' will always evaluate as 'true' [-Waddress]
   85 |             if (tpm2_##otype##_encode_public_##ostructure##_##oformat) \
      |                 ^~~~~
src/tpm2-provider-encoder.c:106:5: note: in expansion of macro 'IMPLEMENT_ENCODER_ENCODE'
  106 |     IMPLEMENT_ENCODER_ENCODE(otype, ostructure, oformat) \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:277:5: note: in expansion of macro 'DECLARE_ENCODER'
  277 |     DECLARE_ENCODER(type, SubjectPublicKeyInfo, pem)
      |     ^~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:307:1: note: in expansion of macro 'DECLARE_ENCODER_X509_PUBKEY'
  307 | DECLARE_ENCODER_X509_PUBKEY(rsa)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c: In function 'tpm2_rsapss_encoder_encode_SubjectPublicKeyInfo_der':
src/tpm2-provider-encoder.c:85:17: warning: the address of 'tpm2_rsapss_encode_public_SubjectPublicKeyInfo_der' will always evaluate as 'true' [-Waddress]
   85 |             if (tpm2_##otype##_encode_public_##ostructure##_##oformat) \
      |                 ^~~~~
src/tpm2-provider-encoder.c:106:5: note: in expansion of macro 'IMPLEMENT_ENCODER_ENCODE'
  106 |     IMPLEMENT_ENCODER_ENCODE(otype, ostructure, oformat) \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:275:5: note: in expansion of macro 'DECLARE_ENCODER'
  275 |     DECLARE_ENCODER(type, SubjectPublicKeyInfo, der) \
      |     ^~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:344:1: note: in expansion of macro 'DECLARE_ENCODER_X509_PUBKEY'
  344 | DECLARE_ENCODER_X509_PUBKEY(rsapss)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c: In function 'tpm2_rsapss_encoder_encode_SubjectPublicKeyInfo_pem':
src/tpm2-provider-encoder.c:85:17: warning: the address of 'tpm2_rsapss_encode_public_SubjectPublicKeyInfo_pem' will always evaluate as 'true' [-Waddress]
   85 |             if (tpm2_##otype##_encode_public_##ostructure##_##oformat) \
      |                 ^~~~~
src/tpm2-provider-encoder.c:106:5: note: in expansion of macro 'IMPLEMENT_ENCODER_ENCODE'
  106 |     IMPLEMENT_ENCODER_ENCODE(otype, ostructure, oformat) \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:277:5: note: in expansion of macro 'DECLARE_ENCODER'
  277 |     DECLARE_ENCODER(type, SubjectPublicKeyInfo, pem)
      |     ^~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:344:1: note: in expansion of macro 'DECLARE_ENCODER_X509_PUBKEY'
  344 | DECLARE_ENCODER_X509_PUBKEY(rsapss)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c: In function 'tpm2_ec_encoder_encode_SubjectPublicKeyInfo_der':
src/tpm2-provider-encoder.c:85:17: warning: the address of 'tpm2_ec_encode_public_SubjectPublicKeyInfo_der' will always evaluate as 'true' [-Waddress]
   85 |             if (tpm2_##otype##_encode_public_##ostructure##_##oformat) \
      |                 ^~~~~
src/tpm2-provider-encoder.c:106:5: note: in expansion of macro 'IMPLEMENT_ENCODER_ENCODE'
  106 |     IMPLEMENT_ENCODER_ENCODE(otype, ostructure, oformat) \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:275:5: note: in expansion of macro 'DECLARE_ENCODER'
  275 |     DECLARE_ENCODER(type, SubjectPublicKeyInfo, der) \
      |     ^~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:424:1: note: in expansion of macro 'DECLARE_ENCODER_X509_PUBKEY'
  424 | DECLARE_ENCODER_X509_PUBKEY(ec)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:88:17: warning: the address of 'tpm2_ec_encode_parameters_SubjectPublicKeyInfo_der' will always evaluate as 'true' [-Waddress]
   88 |             if (tpm2_##otype##_encode_parameters_##ostructure##_##oformat) \
      |                 ^~~~~
src/tpm2-provider-encoder.c:106:5: note: in expansion of macro 'IMPLEMENT_ENCODER_ENCODE'
  106 |     IMPLEMENT_ENCODER_ENCODE(otype, ostructure, oformat) \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:275:5: note: in expansion of macro 'DECLARE_ENCODER'
  275 |     DECLARE_ENCODER(type, SubjectPublicKeyInfo, der) \
      |     ^~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:424:1: note: in expansion of macro 'DECLARE_ENCODER_X509_PUBKEY'
  424 | DECLARE_ENCODER_X509_PUBKEY(ec)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c: In function 'tpm2_ec_encoder_encode_SubjectPublicKeyInfo_pem':
src/tpm2-provider-encoder.c:85:17: warning: the address of 'tpm2_ec_encode_public_SubjectPublicKeyInfo_pem' will always evaluate as 'true' [-Waddress]
   85 |             if (tpm2_##otype##_encode_public_##ostructure##_##oformat) \
      |                 ^~~~~
src/tpm2-provider-encoder.c:106:5: note: in expansion of macro 'IMPLEMENT_ENCODER_ENCODE'
  106 |     IMPLEMENT_ENCODER_ENCODE(otype, ostructure, oformat) \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:277:5: note: in expansion of macro 'DECLARE_ENCODER'
  277 |     DECLARE_ENCODER(type, SubjectPublicKeyInfo, pem)
      |     ^~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:424:1: note: in expansion of macro 'DECLARE_ENCODER_X509_PUBKEY'
  424 | DECLARE_ENCODER_X509_PUBKEY(ec)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:88:17: warning: the address of 'tpm2_ec_encode_parameters_SubjectPublicKeyInfo_pem' will always evaluate as 'true' [-Waddress]
   88 |             if (tpm2_##otype##_encode_parameters_##ostructure##_##oformat) \
      |                 ^~~~~
src/tpm2-provider-encoder.c:106:5: note: in expansion of macro 'IMPLEMENT_ENCODER_ENCODE'
  106 |     IMPLEMENT_ENCODER_ENCODE(otype, ostructure, oformat) \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:277:5: note: in expansion of macro 'DECLARE_ENCODER'
  277 |     DECLARE_ENCODER(type, SubjectPublicKeyInfo, pem)
      |     ^~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c:424:1: note: in expansion of macro 'DECLARE_ENCODER_X509_PUBKEY'
  424 | DECLARE_ENCODER_X509_PUBKEY(ec)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/tpm2-provider-encoder.c: At top level:
src/tpm2-provider-encoder.c:23:36: warning: 'tpm2_encoder_encode_text' declared 'static' but never defined [-Wunused-function]
   23 | static OSSL_FUNC_encoder_encode_fn tpm2_encoder_encode_text;
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~
mv -f src/.deps/tpm2_la-tpm2-provider-encoder.Tpo src/.deps/tpm2_la-tpm2-provider-encoder.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-keymgmt-rsa.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-keymgmt-rsa.Tpo -c -o src/tpm2_la-tpm2-provider-keymgmt-rsa.lo `test -f 'src/tpm2-provider-keymgmt-rsa.c' || echo './'`src/tpm2-provider-keymgmt-rsa.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-keymgmt-rsa.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-keymgmt-rsa.Tpo -c src/tpm2-provider-keymgmt-rsa.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-keymgmt-rsa.o
src/tpm2-provider-keymgmt-rsa.c: In function 'tpm2_rsa_keymgmt_gen':
src/tpm2-provider-keymgmt-rsa.c:302:1: warning: label 'final' defined but not used [-Wunused-label]
  302 | final:
      | ^~~~~
mv -f src/.deps/tpm2_la-tpm2-provider-keymgmt-rsa.Tpo src/.deps/tpm2_la-tpm2-provider-keymgmt-rsa.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-keymgmt-ec.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-keymgmt-ec.Tpo -c -o src/tpm2_la-tpm2-provider-keymgmt-ec.lo `test -f 'src/tpm2-provider-keymgmt-ec.c' || echo './'`src/tpm2-provider-keymgmt-ec.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-keymgmt-ec.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-keymgmt-ec.Tpo -c src/tpm2-provider-keymgmt-ec.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-keymgmt-ec.o
src/tpm2-provider-keymgmt-ec.c: In function 'tpm2_ec_keymgmt_gen':
src/tpm2-provider-keymgmt-ec.c:260:1: warning: label 'final' defined but not used [-Wunused-label]
  260 | final:
      | ^~~~~
mv -f src/.deps/tpm2_la-tpm2-provider-keymgmt-ec.Tpo src/.deps/tpm2_la-tpm2-provider-keymgmt-ec.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-keyexch.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-keyexch.Tpo -c -o src/tpm2_la-tpm2-provider-keyexch.lo `test -f 'src/tpm2-provider-keyexch.c' || echo './'`src/tpm2-provider-keyexch.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-keyexch.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-keyexch.Tpo -c src/tpm2-provider-keyexch.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-keyexch.o
mv -f src/.deps/tpm2_la-tpm2-provider-keyexch.Tpo src/.deps/tpm2_la-tpm2-provider-keyexch.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-asymcipher-rsa.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-asymcipher-rsa.Tpo -c -o src/tpm2_la-tpm2-provider-asymcipher-rsa.lo `test -f 'src/tpm2-provider-asymcipher-rsa.c' || echo './'`src/tpm2-provider-asymcipher-rsa.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-asymcipher-rsa.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-asymcipher-rsa.Tpo -c src/tpm2-provider-asymcipher-rsa.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-asymcipher-rsa.o
mv -f src/.deps/tpm2_la-tpm2-provider-asymcipher-rsa.Tpo src/.deps/tpm2_la-tpm2-provider-asymcipher-rsa.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-digest.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-digest.Tpo -c -o src/tpm2_la-tpm2-provider-digest.lo `test -f 'src/tpm2-provider-digest.c' || echo './'`src/tpm2-provider-digest.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-digest.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-digest.Tpo -c src/tpm2-provider-digest.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-digest.o
mv -f src/.deps/tpm2_la-tpm2-provider-digest.Tpo src/.deps/tpm2_la-tpm2-provider-digest.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" -DPACKAGE_STRING=\"tpm2-openssl\ c4b3352\" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I.    -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-signature.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-signature.Tpo -c -o src/tpm2_la-tpm2-provider-signature.lo `test -f 'src/tpm2-provider-signature.c' || echo './'`src/tpm2-provider-signature.c
libtool: compile:  gcc -DPACKAGE_NAME=\"tpm2-openssl\" -DPACKAGE_TARNAME=\"tpm2-openssl\" -DPACKAGE_VERSION=\"c4b3352\" "-DPACKAGE_STRING=\"tpm2-openssl c4b3352\"" -DPACKAGE_BUGREPORT=\"https://github.com/tpm2-software/tpm2-openssl/issues\" -DPACKAGE_URL=\"https://github.com/tpm2-software/tpm2-openssl\" -DPACKAGE=\"tpm2-openssl\" -DVERSION=\"c4b3352\" -DNDEBUG=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DWITH_TSS2_RC=1 -I. -I/usr/include/tss2 -I/usr/include/tss2 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -MT src/tpm2_la-tpm2-provider-signature.lo -MD -MP -MF src/.deps/tpm2_la-tpm2-provider-signature.Tpo -c src/tpm2-provider-signature.c  -fPIC -DPIC -o src/.libs/tpm2_la-tpm2-provider-signature.o
mv -f src/.deps/tpm2_la-tpm2-provider-signature.Tpo src/.deps/tpm2_la-tpm2-provider-signature.Plo
/bin/sh ./libtool  --tag=CC   --mode=link gcc -I/usr/include/tss2  -I/usr/include/tss2     -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -module -avoid-version -no-undefined -export-symbols-regex 'OSSL_provider_init'    -o tpm2.la -rpath /usr/lib64/ossl-modules src/tpm2_la-tpm2-provider.lo src/tpm2_la-tpm2-provider-core.lo src/tpm2_la-tpm2-provider-types.lo src/tpm2_la-tpm2-provider-x509.lo src/tpm2_la-tpm2-provider-rand.lo src/tpm2_la-tpm2-provider-pkey.lo src/tpm2_la-tpm2-provider-store-object.lo src/tpm2_la-tpm2-provider-decoder-der.lo src/tpm2_la-tpm2-provider-decoder-tss2.lo src/tpm2_la-tpm2-provider-encoder.lo src/tpm2_la-tpm2-provider-keymgmt-rsa.lo src/tpm2_la-tpm2-provider-keymgmt-ec.lo src/tpm2_la-tpm2-provider-keyexch.lo src/tpm2_la-tpm2-provider-asymcipher-rsa.lo src/tpm2_la-tpm2-provider-digest.lo src/tpm2_la-tpm2-provider-signature.lo  -ltss2-esys  -ltss2-tctildr  -lm   -ltss2-rc  -lm 
libtool: link: /usr/bin/nm -B  src/.libs/tpm2_la-tpm2-provider.o src/.libs/tpm2_la-tpm2-provider-core.o src/.libs/tpm2_la-tpm2-provider-types.o src/.libs/tpm2_la-tpm2-provider-x509.o src/.libs/tpm2_la-tpm2-provider-rand.o src/.libs/tpm2_la-tpm2-provider-pkey.o src/.libs/tpm2_la-tpm2-provider-store-object.o src/.libs/tpm2_la-tpm2-provider-decoder-der.o src/.libs/tpm2_la-tpm2-provider-decoder-tss2.o src/.libs/tpm2_la-tpm2-provider-encoder.o src/.libs/tpm2_la-tpm2-provider-keymgmt-rsa.o src/.libs/tpm2_la-tpm2-provider-keymgmt-ec.o src/.libs/tpm2_la-tpm2-provider-keyexch.o src/.libs/tpm2_la-tpm2-provider-asymcipher-rsa.o src/.libs/tpm2_la-tpm2-provider-digest.o src/.libs/tpm2_la-tpm2-provider-signature.o   | /usr/bin/sed -n -e 's/^.*[	 ]\([ABCDGIRSTW][ABCDGIRSTW]*\)[	 ][	 ]*\([_A-Za-z][_A-Za-z0-9]*\)$/\1 \2 \2/p' | /usr/bin/sed '/ __gnu_lto/d' | /usr/bin/sed 's/.* //' | sort | uniq > .libs/tpm2.exp
libtool: link: /usr/bin/grep -E -e "OSSL_provider_init" ".libs/tpm2.exp" > ".libs/tpm2.expT"
libtool: link: mv -f ".libs/tpm2.expT" ".libs/tpm2.exp"
libtool: link: echo "{ global:" > .libs/tpm2.ver
libtool: link:  cat .libs/tpm2.exp | /usr/bin/sed -e "s/\(.*\)/\1;/" >> .libs/tpm2.ver
libtool: link:  echo "local: *; };" >> .libs/tpm2.ver
libtool: link:  gcc -shared  -fPIC -DPIC  src/.libs/tpm2_la-tpm2-provider.o src/.libs/tpm2_la-tpm2-provider-core.o src/.libs/tpm2_la-tpm2-provider-types.o src/.libs/tpm2_la-tpm2-provider-x509.o src/.libs/tpm2_la-tpm2-provider-rand.o src/.libs/tpm2_la-tpm2-provider-pkey.o src/.libs/tpm2_la-tpm2-provider-store-object.o src/.libs/tpm2_la-tpm2-provider-decoder-der.o src/.libs/tpm2_la-tpm2-provider-decoder-tss2.o src/.libs/tpm2_la-tpm2-provider-encoder.o src/.libs/tpm2_la-tpm2-provider-keymgmt-rsa.o src/.libs/tpm2_la-tpm2-provider-keymgmt-ec.o src/.libs/tpm2_la-tpm2-provider-keyexch.o src/.libs/tpm2_la-tpm2-provider-asymcipher-rsa.o src/.libs/tpm2_la-tpm2-provider-digest.o src/.libs/tpm2_la-tpm2-provider-signature.o   -ltss2-esys -ltss2-tctildr -ltss2-rc -lm  -O2 -flto=auto -g -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -mno-omit-leaf-frame-pointer   -Wl,-soname -Wl,tpm2.so -Wl,-version-script -Wl,.libs/tpm2.ver -o .libs/tpm2.so
libtool: link: ( cd ".libs" && rm -f "tpm2.la" && ln -s "../tpm2.la" "tpm2.la" )
```