### PR TITLE
Fedora fix tests

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -159,3 +159,29 @@ make check-code-coverage
 This will run the test suite (`make check`) and build a code coverage report
 detailing the code which was touched.
 
+## Build and run all tests in a container
+
+To make the test setup as reproducible as possible and to reduce the risk
+of damaging the real TPM, a container environment is also available.
+
+Build and run a container with podman (Docker should work as well):
+
+```sh
+TEST_CONTAINER=ubuntu-2204
+# TEST_CONTAINER=fedora-38
+podman build -f "test/Containerfiles/Containerfile.$TEST_CONTAINER" --tag "tpm2-openssl-build-$TEST_CONTAINER"
+podman run -it --name tpm2-openssl-1 -v "$(pwd):/build:Z" --rm --userns=keep-id \
+       "localhost/tpm2-openssl-build-$TEST_CONTAINER" /bin/bash
+```
+
+Run all tests with the swtpm simulator in the container:
+
+```sh
+/build/test/run-with-simulator
+```
+
+Run all tests with the IBM simulator in the container:
+
+```sh
+/build/test/run-with-simulator ibm
+```

--- a/test/Containerfiles/Containerfile.fedora-38
+++ b/test/Containerfiles/Containerfile.fedora-38
@@ -1,0 +1,7 @@
+FROM fedora:38
+
+RUN dnf -y install gcc make pkg-config \
+    autoconf automake libtool autoconf-archive \
+    tpm2-tss-devel openssl-devel tpm2-abrmd \
+    openssl tpm2-tools dbus-daemon swtpm procps-ng git iproute \
+    && mkdir build

--- a/test/Containerfiles/Containerfile.ubuntu-2204
+++ b/test/Containerfiles/Containerfile.ubuntu-2204
@@ -1,0 +1,7 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get -y install \
+    curl autoconf-archive git make build-essential libtool pkg-config \
+    libssl-dev libtss2-dev libtss2-tcti-tabrmd0 \
+    tpm2-abrmd tpm2-tools openssl dbus-daemon swtpm iproute2 systemd \
+    && mkdir build

--- a/test/ec_genpkey_tls_server.sh
+++ b/test/ec_genpkey_tls_server.sh
@@ -30,7 +30,7 @@ DNS.1               = localhost
 EOF
 
 # create a EC private key and then generate a self-signed certificate for it
-openssl req -provider tpm2 -provider default -x509 -config testcert.conf -new -newkey ec -pkeyopt group:P-256 -out testcert.pem
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' -x509 -config testcert.conf -new -newkey ec -pkeyopt group:P-256 -out testcert.pem
 
 # display content of the certificate
 openssl x509 -text -noout -in testcert.pem

--- a/test/ec_pki/ec_pki.sh
+++ b/test/ec_pki/ec_pki.sh
@@ -18,7 +18,7 @@ echo 1000 | tee testdb/{root,intermediate}/{serial,crlnumber}
 chmod 700 testdb/{root,intermediate,client,server}/private
 
 # Create the Root CA Key
-openssl ecparam -provider tpm2 -name $CURVE -genkey -out testdb/root/private/root.key.pem
+openssl ecparam -provider tpm2 -propquery '?provider=tpm2' -name $CURVE -genkey -out testdb/root/private/root.key.pem
 chmod 600 testdb/root/private/root.key.pem
 
 # Create a Self Signed Root Certificate
@@ -34,7 +34,7 @@ openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \
 openssl x509 -noout -text -in testdb/root/certs/root.cert.pem
 
 # Create an Intermediary CA Key
-openssl ecparam -provider tpm2 -name $CURVE -genkey -out testdb/intermediate/private/intermediate.key.pem
+openssl ecparam -provider tpm2 -propquery '?provider=tpm2' -name $CURVE -genkey -out testdb/intermediate/private/intermediate.key.pem
 chmod 600 testdb/intermediate/private/intermediate.key.pem
 
 # Create an Intermediary CSR
@@ -66,7 +66,7 @@ cat testdb/intermediate/certs/intermediate.cert.pem testdb/root/certs/root.cert.
 chmod 444 testdb/intermediate/certs/chain.cert.pem
 
 # Create a Client Key
-openssl ecparam -provider tpm2 -name $CURVE -genkey -out testdb/client/private/agd.key.pem
+openssl ecparam -provider tpm2 -propquery '?provider=tpm2' -name $CURVE -genkey -out testdb/client/private/agd.key.pem
 chmod 400 testdb/client/private/agd.key.pem
 
 # Create a Client CSR

--- a/test/ecdh_create_keyexch_index.sh
+++ b/test/ecdh_create_keyexch_index.sh
@@ -9,7 +9,7 @@ tpm2_create -C owner -G ecc -c testkey1.ctx
 HANDLE=$(tpm2_evictcontrol -c testkey1.ctx | cut -d ' ' -f 2 | head -n 1)
 
 # alice exports public key as PEM
-openssl pkey -provider tpm2 -in handle:${HANDLE} -pubout -out testkey1.pub
+openssl pkey -provider tpm2 -propquery '?provider=tpm2' -in handle:${HANDLE} -pubout -out testkey1.pub
 
 
 # bob generates private key as PEM
@@ -28,7 +28,7 @@ tpm2_nvwrite ${INDEX} -i testkey2.pub
 
 # alice derives her shared secret
 # both alice's private and bob's public key are loaded from the TPM
-openssl pkeyutl -provider tpm2 -provider base -derive -inkey handle:${HANDLE} -peerkey handle:${INDEX} -out secret1.key
+openssl pkeyutl -provider tpm2 -propquery '?provider=tpm2' -provider base -derive -inkey handle:${HANDLE} -peerkey handle:${INDEX} -out secret1.key
 
 # bob also derives his shared secret
 openssl pkeyutl -derive -inkey testkey2.priv -peerkey testkey1.pub -out secret2.key

--- a/test/ecdsa_createak_sign_handle.sh
+++ b/test/ecdsa_createak_sign_handle.sh
@@ -15,10 +15,10 @@ tpm2_createak -C ek_rsa.ctx -G ecc -g sha256 -s ecdsa -c ak_rsa.ctx
 HANDLE=$(tpm2_evictcontrol -c ak_rsa.ctx | cut -d ' ' -f 2 | head -n 1)
 
 # sign using the EK (no scheme/hash needs to be defined)
-openssl pkeyutl -provider tpm2 -inkey handle:${HANDLE} -sign -rawin -in testdata -out testdata.sig
+openssl pkeyutl -provider tpm2 -propquery '?provider=tpm2' -inkey handle:${HANDLE} -sign -rawin -in testdata -out testdata.sig
 
 # export public key
-openssl pkey -provider tpm2 -in handle:${HANDLE} -pubout -out testkey.pub
+openssl pkey -provider tpm2 -propquery '?provider=tpm2' -in handle:${HANDLE} -pubout -out testkey.pub
 
 # verify the signature
 openssl pkeyutl -verify -pubin -inkey testkey.pub -sigfile testdata.sig -rawin -in testdata

--- a/test/ecdsa_genpkey_sign_auth.sh
+++ b/test/ecdsa_genpkey_sign_auth.sh
@@ -6,15 +6,15 @@ set -eufx
 echo -n "abcde12345abcde12345abcde12345ab" > testdata
 
 # generate private key as PEM
-openssl genpkey -provider tpm2 -algorithm EC -pkeyopt group:P-256 \
+openssl genpkey -provider tpm2 -propquery '?provider=tpm2' -algorithm EC -pkeyopt group:P-256 \
     -pkeyopt user-auth:abc -pkeyopt digest:sha256 -out testkey.priv
 
 # read PEM and export public key as PEM
 # note: openssl requests the password although it will not be needed in this case
-openssl pkey -provider tpm2 -provider base -in testkey.priv -passin pass: -pubout -out testkey.pub
+openssl pkey -provider tpm2 -propquery '?provider=tpm2' -provider base -in testkey.priv -passin pass: -pubout -out testkey.pub
 
 # sign using ECDSA and a defined hash
-openssl pkeyutl -provider tpm2 -provider base -sign -inkey testkey.priv -in testdata \
+openssl pkeyutl -provider tpm2 -propquery '?provider=tpm2' -provider base -sign -inkey testkey.priv -in testdata \
     -passin pass:abc -out testdata.sig
 
 # verify the signature

--- a/test/rsa_create_decrypt.sh
+++ b/test/rsa_create_decrypt.sh
@@ -17,13 +17,13 @@ tpm2_load -C primary.ctx -u key.pub -r key.priv -c testkey.ctx
 HANDLE=$(tpm2_evictcontrol -c testkey.ctx | cut -d ' ' -f 2 | head -n 1)
 
 # export public key
-openssl pkey -provider tpm2 -in handle:${HANDLE} -pubout -out testkey.pub
+openssl pkey -provider tpm2 -propquery '?provider=tpm2' -in handle:${HANDLE} -pubout -out testkey.pub
 
 # encrypt data
 openssl pkeyutl -encrypt -pubin -inkey testkey.pub -in testdata -out testdata.crypt
 
 # decrypt data
-openssl pkeyutl -provider tpm2 -inkey handle:${HANDLE} \
+openssl pkeyutl -provider tpm2 -propquery '?provider=tpm2' -inkey handle:${HANDLE} \
     -decrypt -in testdata.crypt -out testdata2
 
 # check the decryption

--- a/test/rsa_createak_auth.sh
+++ b/test/rsa_createak_auth.sh
@@ -15,11 +15,11 @@ tpm2_createak -C ek_rsa.ctx -G rsa -g sha256 -s rsassa -p abc -c ak_rsa.ctx
 HANDLE=$(tpm2_evictcontrol -c ak_rsa.ctx | cut -d ' ' -f 2 | head -n 1)
 
 # sign using the EK (no scheme/hash needs to be defined)
-openssl pkeyutl -provider tpm2 -inkey handle:${HANDLE}?pass -sign -rawin -in testdata \
+openssl pkeyutl -provider tpm2 -propquery '?provider=tpm2' -inkey handle:${HANDLE}?pass -sign -rawin -in testdata \
     -passin pass:abc -out testdata.sig
 
 # export public key
-openssl pkey -provider tpm2 -in handle:${HANDLE} -pubout -out testkey.pub
+openssl pkey -provider tpm2 -propquery '?provider=tpm2' -in handle:${HANDLE} -pubout -out testkey.pub
 
 # verify the signature
 openssl pkeyutl -verify -pubin -inkey testkey.pub -sigfile testdata.sig -rawin -in testdata

--- a/test/rsa_createak_sign_handle.sh
+++ b/test/rsa_createak_sign_handle.sh
@@ -15,10 +15,10 @@ tpm2_createak -C ek_rsa.ctx -G rsa -g sha256 -s rsassa -c ak_rsa.ctx
 HANDLE=$(tpm2_evictcontrol -c ak_rsa.ctx | cut -d ' ' -f 2 | head -n 1)
 
 # sign using the EK (no scheme/hash needs to be defined)
-openssl pkeyutl -provider tpm2 -inkey handle:${HANDLE} -sign -rawin -in testdata -out testdata.sig
+openssl pkeyutl -provider tpm2 -propquery '?provider=tpm2' -inkey handle:${HANDLE} -sign -rawin -in testdata -out testdata.sig
 
 # export public key
-openssl pkey -provider tpm2 -in handle:${HANDLE} -pubout -out testkey.pub
+openssl pkey -provider tpm2 -propquery '?provider=tpm2' -in handle:${HANDLE} -pubout -out testkey.pub
 
 # verify the signature
 openssl pkeyutl -verify -pubin -inkey testkey.pub -sigfile testdata.sig -rawin -in testdata

--- a/test/rsa_createak_sign_object.sh
+++ b/test/rsa_createak_sign_object.sh
@@ -15,10 +15,10 @@ tpm2_createak -C ek_rsa.ctx -G rsa -g sha256 -s rsassa -c ak_rsa.ctx
 HANDLE=$(tpm2_evictcontrol -c ak_rsa.ctx -o ak_rsa.obj | cut -d ' ' -f 2 | head -n 1)
 
 # sign using the EK (no scheme/hash needs to be defined)
-openssl pkeyutl -provider tpm2 -inkey object:ak_rsa.obj -sign -rawin -in testdata -out testdata.sig
+openssl pkeyutl -provider tpm2 -propquery '?provider=tpm2' -inkey object:ak_rsa.obj -sign -rawin -in testdata -out testdata.sig
 
 # export public key
-openssl pkey -provider tpm2 -in object:ak_rsa.obj -pubout -out testkey.pub
+openssl pkey -provider tpm2 -propquery '?provider=tpm2' -in object:ak_rsa.obj -pubout -out testkey.pub
 
 # verify the signature
 openssl pkeyutl -verify -pubin -inkey testkey.pub -sigfile testdata.sig -rawin -in testdata

--- a/test/rsa_genpkey_auth_parent.sh
+++ b/test/rsa_genpkey_auth_parent.sh
@@ -13,19 +13,19 @@ HANDLE=$(tpm2_evictcontrol -c parent.ctx | cut -d ' ' -f 2 | head -n 1)
 # generate key with an user authorization
 # note: verify that pkeyopt parent-auth overrides env
 TPM2OPENSSL_PARENT_AUTH=789 \
-openssl genpkey -provider tpm2 -algorithm RSA -out testkey.priv \
+openssl genpkey -provider tpm2 -propquery '?provider=tpm2' -algorithm RSA -out testkey.priv \
     -pkeyopt parent:${HANDLE} -pkeyopt parent-auth:123 -pkeyopt user-auth:abc -pkeyopt bits:1024
 
 # export public key
 # note: openssl requests the password although it will not be needed in this case
 # note: pkeyopt is not supported in this command so parent-auth goes through env.
 TPM2OPENSSL_PARENT_AUTH=123 \
-openssl pkey -provider tpm2 -provider base -in testkey.priv -passin pass: -pubout -out testkey.pub
+openssl pkey -provider tpm2 -propquery '?provider=tpm2' -provider base -in testkey.priv -passin pass: -pubout -out testkey.pub
 
 # sign using a defined scheme/hash
 # note: pkeyopt parent-auth:123 is not supported in this command so parent-auth goes through env.
 TPM2OPENSSL_PARENT_AUTH=123 \
-openssl pkeyutl -provider tpm2 -provider base -sign -inkey testkey.priv -rawin -in testdata \
+openssl pkeyutl -provider tpm2 -propquery '?provider=tpm2' -provider base -sign -inkey testkey.priv -rawin -in testdata \
     -passin pass:abc -pkeyopt pad-mode:pss -out testdata.sig
 
 # verify the signature

--- a/test/rsa_genpkey_x509_cmp.sh
+++ b/test/rsa_genpkey_x509_cmp.sh
@@ -9,7 +9,7 @@ function cleanup()
 }
 
 # create root CA key and certificate
-openssl req -provider tpm2 -provider default -x509 -newkey rsa:2048 -sha256 -nodes \
+openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' -x509 -newkey rsa:2048 -sha256 -nodes \
             -subj "/C=GB/CN=root.example.com" -extensions v3_ca \
             -keyout test-ca-key.pem -out test-ca-cert.pem
 
@@ -47,7 +47,7 @@ trap "cleanup" EXIT
 sleep 1
 
 # send CMP Initial Request for certificate deployment
-openssl cmp -provider tpm2 -provider default -propquery tpm2.digest!=yes \
+openssl cmp -provider tpm2 -provider default -propquery '?provider=tpm2,tpm2.digest!=yes' \
             -cmd ir -server localhost:8880/pkix/ -recipient "/CN=CMPserver" \
             -secret pass:1234-5678 -newkey test-client-key.pem -subject "/CN=Client" \
             -certout test-my-cert.pem -cacertsout test-my-ca.pem
@@ -78,7 +78,7 @@ sleep 1
 
 # send CMP Key Update Request
 # FIXME: Temporarily use key2/cert2 to authenticate the message, see https://github.com/openssl/openssl/pull/16050
-openssl cmp -provider tpm2 -provider default -propquery tpm2.digest!=yes \
+openssl cmp -provider tpm2 -provider default -propquery '?provider=tpm2,tpm2.digest!=yes' \
             -cmd kur -server localhost:8881/pkix/ -trusted test-ca-cert.pem \
             -key test-client-key2.pem -cert test-client-cert2.pem \
             -newkey test-client-key2.pem -certout test-my-cert2.pem

--- a/test/run-with-simulator
+++ b/test/run-with-simulator
@@ -1,0 +1,121 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+
+SIM_PORT_DATA=2321
+SIM_PORT_CMD=$((SIM_PORT_DATA+1))
+
+# Run from top dir of this repository
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+TOP_DIR="$(realpath "$SCRIPT_DIR/..")"
+cd "$TOP_DIR" || { echo "Error: cd to cd $TOP_DIR failed"; exit 1; }
+
+
+verify_simulator_is_running() {
+    local pid_tpm=$1
+
+    sleep 1
+    ss -lntp4 2> /dev/null | grep "${pid_tpm}" | grep -q "${SIM_PORT_DATA}"
+    ret_data=$?
+    ss -lntp4 2> /dev/null | grep "${pid_tpm}" | grep -q "${SIM_PORT_CMD}"
+    ret_cmd=$?
+    if [ $ret_data -eq 0 ] && [ $ret_cmd -eq 0 ]; then
+        echo "Simulator with PID ${pid_tpm} bound to port ${SIM_PORT_DATA} and ${SIM_PORT_CMD} successfully."
+        return 0
+    else
+        echo "Error: Port conflict? Cleaning up PID: ${pid_tpm}"
+        return 1
+    fi
+}
+
+build_tpm2_simulator_ibm() (
+    test -d ibmtpm && return
+    echo "---> compiling IBM tpm simulator"
+    mkdir ibmtpm
+    curl -Ls https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm1682.tar.gz | tar xz -C ibmtpm
+    cd ibmtpm/src && make
+)
+
+start_tpm2_simulator_ibm () {
+    build_tpm2_simulator_ibm || return 1
+
+    echo "---> starting IBM tpm simulator"
+    ibmtpm/src/tpm_server &
+    pid_tpm=$!
+    verify_simulator_is_running $pid_tpm
+}
+
+start_tpm2_simulator_swtpm () {
+    echo "---> starting swtpm simulator"
+    swtpm socket --tpm2 \
+        --server port=$SIM_PORT_DATA \
+        --ctrl type=tcp,port=$SIM_PORT_CMD \
+        --flags not-need-init \
+        --tpmstate dir="$PWD" \
+        --seccomp action=none &
+    pid_tpm=$!
+    verify_simulator_is_running $pid_tpm
+}
+
+start_dbusd () {
+    echo "---> starting dbus daemon"
+    dbus-daemon --session --print-address > /tmp/bus-socket-path.txt &
+    sleep 1
+    DBUS_SESSION_BUS_ADDRESS="$(tail -n1 /tmp/bus-socket-path.txt)"
+    export DBUS_SESSION_BUS_ADDRESS
+}
+
+start_tpm2_abrmd() {
+    local tabrmd_tcti=$1
+
+    echo "---> starting abrmd"
+    local tabrmd_name="com.intel.tss2.Tabrmd${SIM_PORT_DATA}"
+    tpm2-abrmd --session --dbus-name="${tabrmd_name}" --tcti "${tabrmd_tcti}:host=localhost,port=${SIM_PORT_DATA}" &
+    TCTI_ADDRESS="tabrmd:bus_name=${tabrmd_name},bus_type=session"
+    TPM2TOOLS_TCTI="$TCTI_ADDRESS"
+    TPM2OPENSSL_TCTI="$TCTI_ADDRESS"
+    export TPM2TOOLS_TCTI
+    export TPM2OPENSSL_TCTI
+    sleep 1
+    busctl --address="${DBUS_SESSION_BUS_ADDRESS}" list | grep "$tabrmd_name"
+}
+
+start_tpm2_sim_env() {
+    local sim_type=$1
+
+    start_dbusd
+
+    if [ "$sim_type" = "swtpm" ]; then
+        start_tpm2_simulator_swtpm || return 1
+        start_tpm2_abrmd swtpm || return 1
+    elif [ "$sim_type" = "ibm" ]; then
+        start_tpm2_simulator_ibm || return 1
+        start_tpm2_abrmd mssim || return 1
+    else
+        echo "invalid tpm simulator typ"
+        return 1
+    fi
+}
+
+make_check () {
+    echo "Running make check"
+    openssl version
+    tpm2_getcap properties-fixed | head -n 20
+    make check
+}
+
+function cleanup()
+{
+    pkill -P $$
+}
+trap cleanup EXIT
+
+build_tpm2_openssl() {
+    ./bootstrap
+    ./configure CC=gcc --enable-op-digest --enable-op-cipher
+    make
+}
+
+SIM_TYPE=${1:-swtpm}
+build_tpm2_openssl || { echo "Compiling tpm2-openssl failed"; exit 1; }
+start_tpm2_sim_env "${SIM_TYPE}" || { echo "Starting tpm2 simulator failed ($SIM_TYPE)"; exit 1; }
+make_check || { echo "tpm2-openssl make check failed"; exit 1; }


### PR DESCRIPTION
This adds Containers for building and testing tpm2-openssl with a simulator. The swtpm and the IBM simulator are supported. Supported distros are Fedora 38 and Ubuntu 22.04.

Test with podman rootless on Fedora 38. Docker would probably work as well.