### PR TITLE
Add extra docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ However, the application has to:
    provider with operations for file read/write, standard encoders/decoders,
    symmetric ciphers, and hashes.
 
+For further documentation see [latest github docs](docs).
+
 ### [Initialization](docs/initialization.md)
 
 Connect to the TPM2 using the


### PR DESCRIPTION
When I first read the readme, I actually missed that the section headers were links to the docs folder. This adds an extra, explicit link to the docs folder to assist in docs visibility for users. 