### PR TITLE
Support using provider with TLS

### DIFF
--- a/src/tpm2-provider-keymgmt-ec.c
+++ b/src/tpm2-provider-keymgmt-ec.c
@@ -422,6 +422,10 @@ tpm2_ec_keymgmt_get_params(void *keydata, OSSL_PARAM params[])
     p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_EC_PUB_Y);
     if (p != NULL && !tpm2_param_set_BN_from_buffer(p, pkey->data.pub.publicArea.unique.ecc.y))
         goto error;
+    p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY);
+    if (p != NULL && !tpm2_param_set_ecc_point(p, &pkey->data.pub.publicArea.unique.ecc.x,
+                                                  &pkey->data.pub.publicArea.unique.ecc.y))
+        goto error;
     free(details);
     return 1;
 error:
@@ -450,6 +454,7 @@ tpm2_ec_keymgmt_gettable_params(void *provctx)
         OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_PUB_KEY, NULL, 0),
         OSSL_PARAM_BN(OSSL_PKEY_PARAM_EC_PUB_X, NULL, 0),
         OSSL_PARAM_BN(OSSL_PKEY_PARAM_EC_PUB_Y, NULL, 0),
+        OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY, NULL, 0),
         OSSL_PARAM_END
     };
 

--- a/src/tpm2-provider.c
+++ b/src/tpm2-provider.c
@@ -4,6 +4,7 @@
 #include <openssl/params.h>
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>
+#include <openssl/prov_ssl.h>
 
 #include <tss2/tss2_tctildr.h>
 
@@ -362,6 +363,86 @@ tpm2_teardown(void *provctx)
     OPENSSL_clear_free(cprov, sizeof(TPM2_PROVIDER_CTX));
 }
 
+typedef struct tls_group_constants_st {
+    unsigned int group_id;   /* Group ID */
+    unsigned int secbits;    /* Bits of security */
+    int mintls;              /* Minimum TLS version, -1 unsupported */
+    int maxtls;              /* Maximum TLS version (or 0 for undefined) */
+    int mindtls;             /* Minimum DTLS version, -1 unsupported */
+    int maxdtls;             /* Maximum DTLS version (or 0 for undefined) */
+} TLS_GROUP_CONSTANTS;
+
+#define TLS_GROUP_ID_secp192r1 19
+#define TLS_GROUP_ID_secp224r1 21
+#define TLS_GROUP_ID_secp256r1 23
+#define TLS_GROUP_ID_secp384r1 24
+#define TLS_GROUP_ID_secp521r1 25
+
+static const TLS_GROUP_CONSTANTS tls_group_list[] = {
+    { TLS_GROUP_ID_secp192r1, 80, TLS1_VERSION, TLS1_2_VERSION,
+      DTLS1_VERSION, DTLS1_2_VERSION },
+    { TLS_GROUP_ID_secp224r1, 112, TLS1_VERSION, TLS1_2_VERSION,
+      DTLS1_VERSION, DTLS1_2_VERSION },
+    { TLS_GROUP_ID_secp256r1, 128, TLS1_VERSION, 0, DTLS1_VERSION, 0 },
+    { TLS_GROUP_ID_secp384r1, 192, TLS1_VERSION, 0, DTLS1_VERSION, 0 },
+    { TLS_GROUP_ID_secp521r1, 256, TLS1_VERSION, 0, DTLS1_VERSION, 0 },
+};
+
+#define TLS_GROUP_ENTRY(tlsname, realname, algorithm, idx) \
+    { \
+        OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_GROUP_NAME, \
+                               tlsname, \
+                               sizeof(tlsname)), \
+        OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_GROUP_NAME_INTERNAL, \
+                               realname, \
+                               sizeof(realname)), \
+        OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_GROUP_ALG, \
+                               algorithm, \
+                               sizeof(algorithm)), \
+        OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_GROUP_ID, \
+                        (unsigned int *)&tls_group_list[idx].group_id), \
+        OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_GROUP_SECURITY_BITS, \
+                        (unsigned int *)&tls_group_list[idx].secbits), \
+        OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_MIN_TLS, \
+                       (int *)&tls_group_list[idx].mintls),     \
+        OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_MAX_TLS, \
+                       (int *)&tls_group_list[idx].maxtls), \
+        OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_MIN_DTLS, \
+                       (int *)&tls_group_list[idx].mindtls), \
+        OSSL_PARAM_int(OSSL_CAPABILITY_TLS_GROUP_MAX_DTLS, \
+                       (int *)&tls_group_list[idx].maxdtls), \
+        OSSL_PARAM_END \
+    }
+
+static const OSSL_PARAM param_tls_group_list[][10] = {
+    TLS_GROUP_ENTRY("secp192r1", "prime192v1", "EC", 0),
+    TLS_GROUP_ENTRY("P-192", "prime192v1", "EC", 0), /* Alias of previous */
+    TLS_GROUP_ENTRY("secp224r1", "secp224r1", "EC", 1),
+    TLS_GROUP_ENTRY("P-224", "secp224r1", "EC", 1), /* Alias of previous */
+    TLS_GROUP_ENTRY("secp256r1", "prime256v1", "EC", 2),
+    TLS_GROUP_ENTRY("P-256", "prime256v1", "EC", 2), /* Alias of previous */
+    TLS_GROUP_ENTRY("secp384r1", "secp384r1", "EC", 3),
+    TLS_GROUP_ENTRY("P-384", "secp384r1", "EC", 3), /* Alias of previous */
+    TLS_GROUP_ENTRY("secp521r1", "secp521r1", "EC", 4),
+    TLS_GROUP_ENTRY("P-521", "secp521r1", "EC", 4), /* Alias of above */
+};
+
+static int tpm2_get_capabilities(void *provctx, const char *capability,
+                                 OSSL_CALLBACK *cb, void *arg)
+{
+    if (OPENSSL_strcasecmp(capability, "TLS-GROUP") == 0) {
+        size_t i;
+
+        for (i = 0; i < NELEMS(param_tls_group_list); i++)
+            if (!cb(param_tls_group_list[i], arg))
+                return 0;
+
+        return 1;
+    }
+
+    return 0;
+}
+
 static const OSSL_DISPATCH tpm2_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (void (*)(void))tpm2_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))tpm2_get_params },
@@ -370,6 +451,7 @@ static const OSSL_DISPATCH tpm2_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_GET_REASON_STRINGS, (void (*)(void))tpm2_get_reason_strings },
     { OSSL_FUNC_PROVIDER_SELF_TEST, (void (*)(void))tpm2_self_test },
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))tpm2_teardown },
+    { OSSL_FUNC_PROVIDER_GET_CAPABILITIES, (void (*)(void))tpm2_get_capabilities },
     { 0, NULL }
 };
 


### PR DESCRIPTION
 - ecc: implement get_params for ENCODED_PUBLIC_KEY
   Implement get_params for OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY since this is required for OpenSSL's
   TLS implementation.

 - Support using provider with TLS
   Support returning TLS-GROUP capabilities for well-known TLS groups corresponding to ECC groups the provider may
   support.

   Fixes: #62