### PR TITLE
Fix Windows build after recent commit

### DIFF
--- a/tpm2-openssl.vcxproj
+++ b/tpm2-openssl.vcxproj
@@ -154,7 +154,7 @@
     <ClCompile Include="src\tpm2-provider-pkey.c" />
     <ClCompile Include="src\tpm2-provider-rand.c" />
     <ClCompile Include="src\tpm2-provider-signature.c" />
-    <ClCompile Include="src\tpm2-provider-store-object.c" />
+    <ClCompile Include="src\tpm2-provider-store-handle.c" />
     <ClCompile Include="src\tpm2-provider-types.c" />
     <ClCompile Include="src\tpm2-provider-x509.c" />
     <ClCompile Include="src\tpm2-provider.c" />


### PR DESCRIPTION
The recent [commit](https://github.com/tpm2-software/tpm2-openssl/commit/0d5b0d7e369aeafe8ae209d50d958d195237251d) updated one of the file names, but this was not reflected in the Windows vcxproj file. Fixed in this PR.