### PR TITLE
Fix release dependencies

### DIFF
--- a/tpm2-openssl.vcxproj
+++ b/tpm2-openssl.vcxproj
@@ -114,7 +114,7 @@
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>$(OpenSslDir)\lib\libcrypto.lib;$(Tpm2TssDir)\x64\Debug\tss2-esys.lib;$(Tpm2TssDir)\x64\Debug\tss2-mu.lib;$(Tpm2TssDir)\x64\Debug\tss2-tctildr.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OpenSslDir)\lib\libcrypto.lib;$(Tpm2TssDir)\x64\Release\tss2-esys.lib;$(Tpm2TssDir)\x64\Release\tss2-mu.lib;$(Tpm2TssDir)\x64\Release\tss2-tctildr.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -137,7 +137,7 @@
     <Link>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
-      <AdditionalDependencies>$(OpenSslDir)\lib\libcrypto.lib;$(Tpm2TssDir)\x64\Debug\tss2-esys.lib;$(Tpm2TssDir)\x64\Debug\tss2-mu.lib;$(Tpm2TssDir)\x64\Debug\tss2-tctildr.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OpenSslDir)\lib\libcrypto.lib;$(Tpm2TssDir)\x64\Release\tss2-esys.lib;$(Tpm2TssDir)\x64\Release\tss2-mu.lib;$(Tpm2TssDir)\x64\Release\tss2-tctildr.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
The release configurations still search for Debug libs from tpm-tss2. Fixes the directory structure - this is affecting our automation builds.