### PR TITLE
Update Release Flags for Windows build.

### DIFF
--- a/tpm2-openssl.vcxproj
+++ b/tpm2-openssl.vcxproj
@@ -102,9 +102,9 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;TPM2OPENSSL_EXPORTS;WIN32_LEAN_AND_MEAN;PACKAGE_VERSION="1.1.0";NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;TPM2OPENSSL_EXPORTS;WIN32_LEAN_AND_MEAN;PACKAGE_VERSION="1.1.0";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(Tpm2TssDir)\include\;$(OpenSslDir)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
@@ -120,7 +120,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(Tpm2TssDir)\include\;$(OpenSslDir)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_WINDLL;WIN32_LEAN_AND_MEAN;PACKAGE_VERSION="1.1.0";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDLL;_DEBUG;WIN32_LEAN_AND_MEAN;PACKAGE_VERSION="1.1.0";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -130,14 +130,17 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(Tpm2TssDir)\include\;$(OpenSslDir)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_WINDLL;WIN32_LEAN_AND_MEAN;PACKAGE_VERSION="1.1.0";NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;TPM2OPENSSL_EXPORTS;WIN32_LEAN_AND_MEAN;PACKAGE_VERSION="1.1.0";NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Optimization>MaxSpeed</Optimization>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>$(OpenSslDir)\lib\libcrypto.lib;$(Tpm2TssDir)\x64\Release\tss2-esys.lib;$(Tpm2TssDir)\x64\Release\tss2-mu.lib;$(Tpm2TssDir)\x64\Release\tss2-tctildr.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
The current Release build configuration for Windows generates a MultiThreadedDebugDll. This uses the Debug heap on Windows. When paired with the Release versions of the TSS libraries, there are memory errors since the Release TSS library uses a non-debug heap, and the TPM2-Openssl DLL tries to free from the Debug heap. This change fixes that issue and brings it in line with the TSS library DLLs.