### PR TITLE
Fedora 41

### DIFF
--- a/.github/workflows/clang-asan-check.yml
+++ b/.github/workflows/clang-asan-check.yml
@@ -82,9 +82,9 @@ jobs:
 
     - name: Archive log files
       if: ${{ success() || failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: test-report-clang
+        name: test-report-clang-${{ matrix.branch }}
         path: |
           *.log
           test/*.log

--- a/.github/workflows/gcc-distcheck.yml
+++ b/.github/workflows/gcc-distcheck.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Archive log files
       if: ${{ success() || failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: test-report-gcc
         path: |

--- a/Makefile.am
+++ b/Makefile.am
@@ -143,6 +143,7 @@ EXTRA_DIST = \
     VERSION \
     $(TESTS_SHELL) \
     $(SH_LOG_COMPILER) \
+    test/check_hash_support.sh \
     test/run-with-simulator \
     test/ec_pki/openssl.cnf \
     test/rsa_pki/etc

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -168,7 +168,7 @@ Build and run a container with podman (Docker should work as well):
 
 ```sh
 TEST_CONTAINER=ubuntu-2204
-# TEST_CONTAINER=fedora-38
+# TEST_CONTAINER=fedora-41
 podman build -f "test/Containerfiles/Containerfile.$TEST_CONTAINER" --tag "tpm2-openssl-build-$TEST_CONTAINER"
 podman run -it --name tpm2-openssl-1 -v "$(pwd):/build:Z" --rm --userns=keep-id \
        "localhost/tpm2-openssl-build-$TEST_CONTAINER" /bin/bash

--- a/test/Containerfiles/Containerfile.fedora-41
+++ b/test/Containerfiles/Containerfile.fedora-41
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM fedora:41
 
 RUN dnf -y install gcc make pkg-config \
     autoconf automake libtool autoconf-archive \

--- a/test/Containerfiles/Containerfile.fedora-rawhide
+++ b/test/Containerfiles/Containerfile.fedora-rawhide
@@ -1,0 +1,7 @@
+FROM fedora:rawhide
+
+RUN dnf -y install gcc make pkg-config \
+    autoconf automake libtool autoconf-archive \
+    tpm2-tss-devel openssl-devel tpm2-abrmd \
+    openssl tpm2-tools dbus-daemon swtpm procps-ng git iproute \
+    && mkdir build

--- a/test/Containerfiles/Containerfile.ubuntu-2404
+++ b/test/Containerfiles/Containerfile.ubuntu-2404
@@ -1,0 +1,7 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get -y install \
+    curl autoconf-archive git make build-essential libtool pkg-config \
+    libssl-dev libtss2-dev libtss2-tcti-tabrmd0 \
+    tpm2-abrmd tpm2-tools openssl dbus-daemon swtpm iproute2 systemd \
+    && mkdir build

--- a/test/check_hash_support.sh
+++ b/test/check_hash_support.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+
+# SHA-1 is considered as insecure by some Linux distributions.
+# So far there is no official API to detect SHA-1 support at run-time.
+# This script checks if a hash is supported for signing.
+# More details: https://fedoraproject.org/wiki/SHA1SignaturesGuidance
+
+set -e -o pipefail
+
+tmpdir=$(mktemp -d)
+cleanup() {
+    rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+if [ $# -eq 1 ]; then
+    DGST_ALGO=$1
+else
+    echo "Please pass the algorithm. Example sha1"
+    exit 1
+fi
+
+# TPM2 must support it
+tpm2_getcap algorithms | grep -q "$DGST_ALGO"
+
+# openssl must support it
+openssl genpkey -algorithm RSA -out "$tmpdir/private_key.pem" -pkeyopt rsa_keygen_bits:2048 &>/dev/null
+openssl rsa -pubout -in "$tmpdir/private_key.pem" -out "$tmpdir/public_key.pem" &>/dev/null
+echo "Some data" > "$tmpdir/data.txt"
+openssl dgst "-$DGST_ALGO" -sign "$tmpdir/private_key.pem" -out "$tmpdir/signature" "$tmpdir/data.txt" &>/dev/null
+openssl dgst "-$DGST_ALGO" -verify "$tmpdir/public_key.pem" -signature "$tmpdir/signature" "$tmpdir/data.txt" &>/dev/null

--- a/test/ecdsa_genpkey_sign_rawin.sh
+++ b/test/ecdsa_genpkey_sign_rawin.sh
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 set -eufx
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 echo -n "abcde12345abcde12345" > testdata
 
 # generate private key as PEM
@@ -13,7 +15,7 @@ openssl pkey -provider tpm2 -provider base -in testkey.priv -pubout -out testkey
 # check various digests
 for HASH in sha1 sha256 sha384 sha512; do
     # skip unsupported algorithms
-    tpm2_getcap algorithms | grep $HASH || continue
+    "$SCRIPT_DIR/check_hash_support.sh" $HASH || continue
 
     # sign using ECDSA and a defined hash
     openssl pkeyutl -provider tpm2 -provider base -sign -inkey testkey.priv -rawin -in testdata \

--- a/test/rsa_genpkey_sign_rawin.sh
+++ b/test/rsa_genpkey_sign_rawin.sh
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 set -eufx
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 echo -n "abcde12345abcde12345" > testdata
 
 # generate key with no scheme/hash constraints
@@ -13,7 +15,7 @@ openssl pkey -provider tpm2 -provider base -in testkey.priv -pubout -out testkey
 # check default scheme with various digests
 for HASH in sha1 sha256 sha384 sha512; do
     # skip unsupported algorithms
-    tpm2_getcap algorithms | grep $HASH || continue
+    "$SCRIPT_DIR/check_hash_support.sh" $HASH || continue
 
     # sign using a defined scheme/hash
     openssl pkeyutl -provider tpm2 -provider base -sign -inkey testkey.priv -rawin -in testdata \

--- a/test/rsa_genpkey_x509_csr.sh
+++ b/test/rsa_genpkey_x509_csr.sh
@@ -3,7 +3,7 @@
 set -eufx
 
 # create a TPM based private key
-openssl genpkey -provider tpm2 -algorithm RSA -pkeyopt bits:2048 -out rootca.key
+openssl genpkey -provider tpm2 -propquery '?provider=tpm2' -algorithm RSA -pkeyopt bits:2048 -out rootca.key
 
 # create a self-signed CA certificate
 openssl req -provider tpm2 -provider default -propquery '?provider=tpm2' \

--- a/test/rsa_pki/etc/email.conf
+++ b/test/rsa_pki/etc/email.conf
@@ -6,7 +6,7 @@
 [ req ]
 default_bits            = 2048                  # RSA key size
 encrypt_key             = no
-default_md              = sha1                  # MD to use
+default_md              = sha256                # MD to use
 utf8                    = yes                   # Input is UTF-8
 string_mask             = utf8only              # Emit UTF-8 strings
 prompt                  = no                    # Don't prompt for DN

--- a/test/rsa_pki/etc/root-ca.conf
+++ b/test/rsa_pki/etc/root-ca.conf
@@ -15,7 +15,7 @@ dir                     = testdb                # Top dir
 [ req ]
 default_bits            = 2048                  # RSA key size
 encrypt_key             = no
-default_md              = sha1                  # MD to use
+default_md              = sha256                # MD to use
 utf8                    = yes                   # Input is UTF-8
 string_mask             = utf8only              # Emit UTF-8 strings
 prompt                  = no                    # Don't prompt for DN
@@ -50,7 +50,7 @@ crlnumber               = $dir/ca/$ca/db/$ca.crl.srl # CRL number file
 database                = $dir/ca/$ca/db/$ca.db # Index file
 unique_subject          = no                    # Require unique subject
 default_days            = 3652                  # How long to certify for
-default_md              = sha1                  # MD to use
+default_md              = sha256                # MD to use
 policy                  = match_pol             # Default naming policy
 email_in_dn             = no                    # Add email to cert DN
 preserve                = no                    # Keep passed DN ordering

--- a/test/rsa_pki/etc/server.conf
+++ b/test/rsa_pki/etc/server.conf
@@ -9,7 +9,7 @@ SAN                     = DNS:yourdomain.tld    # Default value
 [ req ]
 default_bits            = 2048                  # RSA key size
 encrypt_key             = no
-default_md              = sha1                  # MD to use
+default_md              = sha256                # MD to use
 utf8                    = yes                   # Input is UTF-8
 string_mask             = utf8only              # Emit UTF-8 strings
 prompt                  = no                    # Don't prompt for DN

--- a/test/rsa_pki/etc/signing-ca.conf
+++ b/test/rsa_pki/etc/signing-ca.conf
@@ -15,7 +15,7 @@ dir                     = testdb                # Top dir
 [ req ]
 default_bits            = 2048                  # RSA key size
 encrypt_key             = no
-default_md              = sha1                  # MD to use
+default_md              = sha256                # MD to use
 utf8                    = yes                   # Input is UTF-8
 string_mask             = utf8only              # Emit UTF-8 strings
 prompt                  = no                    # Don't prompt for DN
@@ -50,7 +50,7 @@ crlnumber               = $dir/ca/$ca/db/$ca.crl.srl # CRL number file
 database                = $dir/ca/$ca/db/$ca.db # Index file
 unique_subject          = no                    # Require unique subject
 default_days            = 730                   # How long to certify for
-default_md              = sha1                  # MD to use
+default_md              = sha256                # MD to use
 policy                  = match_pol             # Default naming policy
 email_in_dn             = no                    # Add email to cert DN
 preserve                = no                    # Keep passed DN ordering

--- a/test/rsapss_genpkey_sign_rawin.sh
+++ b/test/rsapss_genpkey_sign_rawin.sh
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 set -eufx
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 echo -n "abcde12345abcde12345" > testdata
 
 # check default scheme with various digests
 for HASH in sha1 sha256 sha384 sha512; do
     # skip unsupported algorithms
-    tpm2_getcap algorithms | grep $HASH || continue
+    "$SCRIPT_DIR/check_hash_support.sh" $HASH || continue
 
     # generate key with no scheme/hash constraints
     openssl genpkey -provider tpm2 -algorithm RSA-PSS -pkeyopt bits:1024 \


### PR DESCRIPTION
The default security policy of Fedora 41 is going to block SHA-1. This pull request adds support to the tests.

Fixes: https://bugzilla-attachments.redhat.com/attachment.cgi?id=2042901