### PR TITLE
tests: fix use of `EVP_PKEY_Q_keygen` with `size_t` variadic argument

### DIFF
--- a/test/rsa_genpkey_decrypt.c
+++ b/test/rsa_genpkey_decrypt.c
@@ -26,7 +26,7 @@ int main()
         goto error;
 
     /* generate a RSA-2048 key using the TPM2 */
-    if (!(privkey = EVP_PKEY_Q_keygen(NULL, "provider=tpm2", "RSA", 2048)))
+    if (!(privkey = EVP_PKEY_Q_keygen(NULL, "provider=tpm2", "RSA", (size_t)2048)))
         goto error;
 
     /* export the public key */


### PR DESCRIPTION
Fix case where `int` argument was passed instead of `size_t`.

https://github.com/openssl/openssl/pull/25857