### PR TITLE
Fixing tpm2-tss url from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The tpm2-openssl project
   from the Trusted Computing Groups (TCG)
   [TPM Software Stack (TSS 2.0)](https://trustedcomputinggroup.org/work-groups/software-stack/)
   and uses the
-  [tpm2-tss](https://www.github.org/tpm2-software/tpm2-tss) software stack
+  [tpm2-tss](https://github.com/tpm2-software/tpm2-tss) software stack
   implementation, version 3.2.0 or later.
 
 


### PR DESCRIPTION
Hi,
Following the README.md I found this small typo for the `tpm2-tss` Github repository.