### PR TITLE
Fix wrong ECDSA algorithm-identifier

### DIFF
--- a/src/tpm2-provider-x509.c
+++ b/src/tpm2-provider-x509.c
@@ -210,7 +210,7 @@ tpm2_get_ecdsa_algor(TPM2_ALG_ID digalg)
 
     if ((x509_algor = X509_ALGOR_new()) == NULL)
         return NULL;
-    X509_ALGOR_set0(x509_algor, oid, V_ASN1_NULL, NULL);
+    X509_ALGOR_set0(x509_algor, oid, V_ASN1_UNDEF, NULL);
 
     return x509_algor;
 }


### PR DESCRIPTION
RFC 5758 specifies in section 3.2 ECDSA Signature Algorithm the following:

> When the ecdsa-with-SHA224, ecdsa-with-SHA256, ecdsa-with-SHA384, or
>  ecdsa-with-SHA512 algorithm identifier appears in the algorithm field
>  as an AlgorithmIdentifier, the encoding MUST omit the parameters
> field.

Using `V_ASN1_NULL` adds the NULL parameter `30 0C 06 08 2A 86 48 CE 3D 04 03 02 05 00`
Decoded:
```
SEQUENCE (2 elem)
     OBJECT IDENTIFIER 1.2.840.10045.4.3.2 ecdsaWithSHA256 (ANSI X9.62 ECDSA algorithm with SHA256)
    [0] [?] NULL 
```

    
Using `V_ASN1_UNDEF` creates the desired ASN1 structure `30 0A 06 08 2A 86 48 CE 3D 04 03 02`:
```
SEQUENCE (1 elem)
    OBJECT IDENTIFIER 1.2.840.10045.4.3.2 ecdsaWithSHA256 (ANSI X9.62 ECDSA algorithm with SHA256)
```

