### PR TITLE
Use sem_destroy instead sem_close

### DIFF
--- a/src/tpm2-provider-semaphore.c
+++ b/src/tpm2-provider-semaphore.c
@@ -68,7 +68,7 @@ int tpm2_semaphore_unlock(tpm2_semaphore_t sem)
 
 void tpm2_semaphore_free(tpm2_semaphore_t sem)
 {
-    sem_close(sem);
+    sem_destroy(sem);
     munmap(sem, sizeof(sem_t));
 }
 


### PR DESCRIPTION
Sem_destroy is correct way to get rid of unnamed semaphore

Fixes #141 and #142