### PR TITLE
Support import export TPM private keys

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -105,6 +105,7 @@ TESTS_SHELL = test/list.sh \
               test/rsa_createak_sign_handle.sh \
               test/rsa_create_decrypt_pkcs1.sh \
               test/rsa_create_decrypt_oaep.sh \
+              test/rsa_export_import_private_key.sh \
               test/rsa_genpkey_x509_cert.sh \
               test/rsa_genpkey_x509_cmp.sh \
               test/rsa_genpkey_x509_cms.sh \
@@ -115,6 +116,7 @@ TESTS_SHELL = test/list.sh \
               test/rsapss_createak_tls_server.sh \
               test/rsa_pki/rsa_pki.sh \
               test/ec_genpkey_check.sh \
+              test/ec_export_import_private_key.sh \
               test/ec_genpkey_parameters.sh \
               test/ec_genpkey_x509_cms.sh \
               test/ecdsa_genpkey_sign_auth.sh \

--- a/src/tpm2-provider-pkey.c
+++ b/src/tpm2-provider-pkey.c
@@ -15,6 +15,8 @@ typedef struct {
     ASN1_INTEGER *parent;
     ASN1_OCTET_STRING *pubkey;
     ASN1_OCTET_STRING *privkey;
+    ASN1_INTEGER *privkeyType;
+    ASN1_INTEGER *privkeyHandle;
 } TSSPRIVKEY;
 
 ASN1_SEQUENCE(TSSPRIVKEY) = {
@@ -22,7 +24,9 @@ ASN1_SEQUENCE(TSSPRIVKEY) = {
     ASN1_EXP_OPT(TSSPRIVKEY, emptyAuth, ASN1_BOOLEAN, 0),
     ASN1_SIMPLE(TSSPRIVKEY, parent, ASN1_INTEGER),
     ASN1_SIMPLE(TSSPRIVKEY, pubkey, ASN1_OCTET_STRING),
-    ASN1_SIMPLE(TSSPRIVKEY, privkey, ASN1_OCTET_STRING)
+    ASN1_SIMPLE(TSSPRIVKEY, privkey, ASN1_OCTET_STRING),
+    ASN1_EXP_OPT(TSSPRIVKEY, privkeyType, ASN1_INTEGER, 1),
+    ASN1_EXP_OPT(TSSPRIVKEY, privkeyHandle, ASN1_INTEGER, 2),
 } ASN1_SEQUENCE_END(TSSPRIVKEY)
 
 #define OID_loadableKey "2.23.133.10.1.3"
@@ -62,9 +66,32 @@ tpm2_keydata_write(const TPM2_KEYDATA *keydata, BIO *bout, TPM2_PKEY_FORMAT form
     if (!tpk)
         return 0;
 
-    if (Tss2_MU_TPM2B_PRIVATE_Marshal(&keydata->priv, &privbuf[0],
-                                      sizeof(privbuf), &privbuf_len))
+    if (tpk->privkeyType == NULL) {
+        tpk->privkeyType = ASN1_INTEGER_new();
+        if (tpk->privkeyType == NULL)
+            goto error;
+    };
+    if (!ASN1_INTEGER_set_uint64(tpk->privkeyType, keydata->privatetype))
         goto error;
+
+    switch (keydata->privatetype) {
+    case KEY_TYPE_HANDLE:
+        if (tpk->privkeyHandle == NULL) {
+            tpk->privkeyHandle = ASN1_INTEGER_new();
+            if (tpk->privkeyHandle == NULL)
+                goto error;
+        }
+        if (!ASN1_INTEGER_set_uint64(tpk->privkeyHandle, keydata->handle))
+            goto error;
+        break;
+    case KEY_TYPE_BLOB:
+        if (Tss2_MU_TPM2B_PRIVATE_Marshal(&keydata->priv, &privbuf[0],
+                                          sizeof(privbuf), &privbuf_len))
+            goto error;
+        break;
+    default:
+        goto error;
+    }
 
     if (Tss2_MU_TPM2B_PUBLIC_Marshal(&keydata->pub, &pubbuf[0],
                                      sizeof(pubbuf), &pubbuf_len))
@@ -131,7 +158,6 @@ tpm2_keydata_read(BIO *bin, TPM2_KEYDATA *keydata, TPM2_PKEY_FORMAT format)
     if (tpk == NULL)
         return 0;
 
-    keydata->privatetype = KEY_TYPE_BLOB;
     keydata->emptyAuth = (tpk->emptyAuth != V_ASN1_UNDEF && tpk->emptyAuth);
 
     // the ASN1_INTEGER_get on a 32-bit machine will fail for numbers of UINT32_MAX
@@ -149,10 +175,30 @@ tpm2_keydata_read(BIO *bin, TPM2_KEYDATA *keydata, TPM2_PKEY_FORMAT format)
             strcmp(type_oid, OID_loadableKey))
         goto error;
 
-    if (Tss2_MU_TPM2B_PRIVATE_Unmarshal(ASN1_STRING_get0_data(tpk->privkey),
-                                        ASN1_STRING_length(tpk->privkey), NULL,
-                                        &keydata->priv))
+    uint64_t privkeyType;
+    if (tpk->privkeyType != NULL) {
+        if(!ASN1_INTEGER_get_uint64(&privkeyType, tpk->privkeyType))
+            goto error;
+    } else {
+        privkeyType = KEY_TYPE_BLOB;
+    }
+    keydata->privatetype = privkeyType;
+
+    switch (keydata->privatetype) {
+    case KEY_TYPE_HANDLE:
+        if (tpk->privkeyType != NULL
+            && !ASN1_INTEGER_get_uint64((uint64_t *)&keydata->handle, tpk->privkeyHandle))
+                goto error;
+        break;
+    case KEY_TYPE_BLOB:
+        if (Tss2_MU_TPM2B_PRIVATE_Unmarshal(ASN1_STRING_get0_data(tpk->privkey),
+                                            ASN1_STRING_length(tpk->privkey), NULL,
+                                            &keydata->priv))
+            goto error;
+        break;
+    default:
         goto error;
+    }
 
     if (Tss2_MU_TPM2B_PUBLIC_Unmarshal(ASN1_STRING_get0_data(tpk->pubkey),
                                        ASN1_STRING_length(tpk->pubkey), NULL,

--- a/src/tpm2-provider.c
+++ b/src/tpm2-provider.c
@@ -207,10 +207,16 @@ static const OSSL_ALGORITHM tpm2_encoders[] = {
     /* private key */
     { "RSA", "provider=tpm2,output=der,structure=PrivateKeyInfo", tpm2_tss_encoder_PrivateKeyInfo_der_functions },
     { "RSA", "provider=tpm2,output=pem,structure=PrivateKeyInfo", tpm2_tss_encoder_PrivateKeyInfo_pem_functions },
+    { "RSA", "provider=tpm2,output=der,structure=type-specific", tpm2_tss_encoder_PrivateKeyInfo_der_functions },
+    { "RSA", "provider=tpm2,output=pem,structure=type-specific", tpm2_tss_encoder_PrivateKeyInfo_pem_functions },
     { "RSA-PSS", "provider=tpm2,output=der,structure=PrivateKeyInfo", tpm2_tss_encoder_PrivateKeyInfo_der_functions },
     { "RSA-PSS", "provider=tpm2,output=pem,structure=PrivateKeyInfo", tpm2_tss_encoder_PrivateKeyInfo_pem_functions },
+    { "RSA-PSS", "provider=tpm2,output=der,structure=type-specific", tpm2_tss_encoder_PrivateKeyInfo_der_functions },
+    { "RSA-PSS", "provider=tpm2,output=pem,structure=type-specific", tpm2_tss_encoder_PrivateKeyInfo_pem_functions },
     { "EC", "provider=tpm2,output=der,structure=PrivateKeyInfo", tpm2_tss_encoder_PrivateKeyInfo_der_functions },
     { "EC", "provider=tpm2,output=pem,structure=PrivateKeyInfo", tpm2_tss_encoder_PrivateKeyInfo_pem_functions },
+    { "EC", "provider=tpm2,output=der,structure=type-specific", tpm2_tss_encoder_PrivateKeyInfo_der_functions },
+    { "EC", "provider=tpm2,output=pem,structure=type-specific", tpm2_tss_encoder_PrivateKeyInfo_pem_functions },
     /* public key */
     { "RSA", "provider=tpm2,output=der,structure=pkcs1", tpm2_rsa_encoder_pkcs1_der_functions },
     { "RSA", "provider=tpm2,output=pem,structure=pkcs1", tpm2_rsa_encoder_pkcs1_pem_functions },

--- a/test/ec_export_import_private_key.sh
+++ b/test/ec_export_import_private_key.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+set -eufx
+
+EXPECTED=expected_params.pem
+COMPUTED=params.pem
+
+cat > ${EXPECTED} <<EOF
+-----BEGIN EC PARAMETERS-----
+BggqhkjOPQMBBw==
+-----END EC PARAMETERS-----
+EOF
+
+# create primary
+tpm2_createprimary -G ecc -g sha256 -c primary.ctx
+
+# make the primary persistent
+HANDLE=$(tpm2_evictcontrol -c primary.ctx | cut -d ' ' -f 2 | head -n 1)
+
+# Export the private key through the specified handle
+openssl ec -provider tpm2 -provider default -in "handle:${HANDLE}" -out primary_key.pem
+
+# Import the private key and export the parameters
+openssl ec -provider tpm2 -provider default -in primary_key.pem -param_out -out ${COMPUTED}
+
+# Simple test, check if the parameter is equals
+if cmp -s "${EXPECTED}" "${COMPUTED}" ;
+then
+    echo "Expected params are equals!"
+else
+    echo "Expected params differ. Expected:"
+    cat ${EXPECTED}
+    echo "Got: "
+    cat ${COMPUTED}
+    exit 1
+fi
+
+# release the persistent key
+tpm2_evictcontrol -c ${HANDLE}
+
+rm primary.ctx primary_key.pem ${EXPECTED} ${COMPUTED}

--- a/test/rsa_export_import_private_key.sh
+++ b/test/rsa_export_import_private_key.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+set -eufx
+
+# create primary
+tpm2_createprimary -G rsa -g sha256 -c primary.ctx
+
+# make the primary persistent
+HANDLE=$(tpm2_evictcontrol -c primary.ctx | cut -d ' ' -f 2 | head -n 1)
+
+# Export the private key through the specified handle
+openssl rsa -provider tpm2 -provider default -in "handle:${HANDLE}" -out primary_key.pem
+
+# Import the private key and print the modulus
+openssl rsa -provider tpm2 -provider default -in primary_key.pem -modulus -noout
+
+# release the persistent key
+tpm2_evictcontrol -c ${HANDLE}
+
+rm primary.ctx primary_key.pem


### PR DESCRIPTION
This commit adds support to export a primary key from the TPM by saving the key-type and a key handle in the ASN1 structure inside the TSS2 PRIVATE KEY. The biggest change is on [line 134](https://github.com/tpm2-software/tpm2-openssl/compare/master...smhmeier:tpm2-openssl:add-key-handle-serialization?expand=1#diff-b7d2c2757e9c2e3ca8b0f9c475fa9921fc8b4f569a2cacdc43393fbf37c470dbL134) in file `src/tpm2-provider-pkey.c` where instead of simply assuming `KEY_TYPE_BLOB`, I check if a handle is used instead. Without it, the [part that handles](https://github.com/tpm2-software/tpm2-openssl/blob/master/src/tpm2-provider-decoder-tss2.c#L99-L106) `KEY_TYPE_HANDLE` is never called.

 I decided to use two additional, but optional, fields in the ASN1 structure. Another approach would be to use the existing `privkey` field and interpret it according to the `privkeyType`.

---

The main application for this change is being able to export the key as seen in the test:
```bash
openssl ec -provider tpm2 -in "handle:${HANDLE}" -out primary_key.pem
```

This output file can then be used in `curl` for mTLS.
```bash
curl --cert ${CLIENT_CERT_FILE} \
     --capath ${ROOT_CA_DIR} \
     --key primary_key.pem \
     --engine "tpm2" \
     <server>
```