### PR TITLE
Cleanse-before-free buffers for sensitive data

### DIFF
--- a/src/tpm2-provider-asymcipher-rsa.c
+++ b/src/tpm2-provider-asymcipher-rsa.c
@@ -4,6 +4,7 @@
 
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>
+#include <openssl/crypto.h>
 #include <openssl/params.h>
 #include <openssl/rsa.h>
 
@@ -119,7 +120,7 @@ rsa_asymcipher_freectx(void *ctx)
     if (actx == NULL)
         return;
 
-    free(actx->message);
+    cleanse_free(actx->message, sizeof(TPM2B_PUBLIC_KEY_RSA));
     OPENSSL_clear_free(actx, sizeof(TPM2_RSA_ASYMCIPHER_CTX));
 }
 
@@ -220,4 +221,3 @@ const OSSL_DISPATCH tpm2_rsa_asymcipher_functions[] = {
     { OSSL_FUNC_ASYM_CIPHER_SETTABLE_CTX_PARAMS, (void (*)(void))rsa_asymcipher_settable_ctx_params },
     { 0, NULL }
 };
-

--- a/src/tpm2-provider-cipher.c
+++ b/src/tpm2-provider-cipher.c
@@ -5,6 +5,7 @@
 #include <openssl/core_dispatch.h>
 #include <openssl/crypto.h>
 #include <openssl/core_names.h>
+#include <openssl/crypto.h>
 #include <openssl/params.h>
 
 #include <tss2/tss2_mu.h>
@@ -147,7 +148,7 @@ tpm2_load_external_key(TPM2_CIPHER_CTX *cctx, ESYS_TR parent,
                       ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                       keyPrivate, keyPublic, &cctx->object);
         free(keyPublic);
-        free(keyPrivate);
+        cleanse_free(keyPrivate, sizeof(TPM2B_PRIVATE));
     }
     tpm2_semaphore_unlock(cctx->esys_lock);
     TPM2_CHECK_RC(cctx->core, r, TPM2_ERR_CANNOT_CREATE_KEY, return 0);
@@ -290,10 +291,10 @@ tpm2_cipher_process_buffer(TPM2_CIPHER_CTX *cctx, int padded,
     memcpy(out + *outl, outbuff->buffer, outbuff->size);
     *outl += outbuff->size;
 
-    free(outbuff);
+    cleanse_free(outbuff, sizeof(TPM2B_MAX_BUFFER));
     return 1;
 error:
-    free(outbuff);
+    cleanse_free(outbuff, sizeof(TPM2B_MAX_BUFFER));
     return 0;
 }
 
@@ -394,14 +395,13 @@ tpm2_cipher_update_stream(void *ctx,
 
         if (outbuff->size < consume
                 || *outl + consume > outsize) {
-            free(outbuff);
+            cleanse_free(outbuff, sizeof(TPM2B_MAX_BUFFER));
             return 0;
         }
         /* in a stream cipher we may skip the padding bytes */
         memcpy(out + *outl, outbuff->buffer, consume);
         *outl += consume;
-
-        free(outbuff);
+        cleanse_free(outbuff, sizeof(TPM2B_MAX_BUFFER));
     }
 
     return 1;
@@ -564,4 +564,3 @@ DECLARE_3CIPHERS(CAMELLIA,CBC,128,128,block)
 DECLARE_3CIPHERS(CAMELLIA,OFB,128,128,stream)
 DECLARE_3CIPHERS(CAMELLIA,CFB,128,128,stream)
 DECLARE_3CIPHERS(CAMELLIA,CTR,128,128,stream)
-

--- a/src/tpm2-provider-keyexch.c
+++ b/src/tpm2-provider-keyexch.c
@@ -138,7 +138,7 @@ tpm2_keyexch_derive_kdf(TPM2_KEYEXCH_CTX *kexc, unsigned char *secret,
 error:
     EVP_KDF_CTX_free(kctx);
     EVP_KDF_free(kdf);
-    free(outPoint);
+    cleanse_free(outPoint, sizeof(TPM2B_ECC_POINT));
     return res;
 }
 
@@ -163,13 +163,13 @@ tpm2_keyexch_derive_plain(TPM2_KEYEXCH_CTX *kexc, unsigned char *secret,
     *secretlen = outPoint->point.x.size;
     if (secret != NULL) {
         if (*secretlen > outlen) {
-            free(outPoint);
+            cleanse_free(outPoint, sizeof(TPM2B_ECC_POINT));
             return 0;
         }
         memcpy(secret, outPoint->point.x.buffer, *secretlen);
     }
 
-    free(outPoint);
+    cleanse_free(outPoint, sizeof(TPM2B_ECC_POINT));
     return 1;
 }
 
@@ -260,4 +260,3 @@ const OSSL_DISPATCH tpm2_ecdh_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS, (void(*)(void))tpm2_keyexch_settable_ctx_params },
     { 0, NULL }
 };
-

--- a/src/tpm2-provider-keymgmt-ec.c
+++ b/src/tpm2-provider-keymgmt-ec.c
@@ -261,7 +261,7 @@ tpm2_ec_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
                   ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                   keyPrivate, keyPublic, &pkey->object);
     free(keyPublic);
-    free(keyPrivate);
+    cleanse_free(keyPrivate, sizeof(TPM2B_PRIVATE));
     TPM2_CHECK_RC(gen->core, r, TPM2_ERR_CANNOT_CREATE_KEY, goto error1);
 
     if (gen->parentHandle && gen->parentHandle != TPM2_RH_OWNER)
@@ -697,4 +697,3 @@ const OSSL_DISPATCH *tpm2_ec_keymgmt_dispatch(const TPM2_CAPABILITY *capability)
     else
         return NULL;
 }
-

--- a/src/tpm2-provider-keymgmt-rsa.c
+++ b/src/tpm2-provider-keymgmt-rsa.c
@@ -303,7 +303,7 @@ tpm2_rsa_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
                   ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                   keyPrivate, keyPublic, &pkey->object);
     free(keyPublic);
-    free(keyPrivate);
+    cleanse_free(keyPrivate, sizeof(TPM2B_PRIVATE));
     TPM2_CHECK_RC(gen->core, r, TPM2_ERR_CANNOT_CREATE_KEY, goto error2);
 
     if (gen->parentHandle && gen->parentHandle != TPM2_RH_OWNER)
@@ -663,4 +663,3 @@ const OSSL_DISPATCH *tpm2_rsapss_keymgmt_dispatch(const TPM2_CAPABILITY *capabil
     else
         return NULL;
 }
-

--- a/src/tpm2-provider-store-handle.c
+++ b/src/tpm2-provider-store-handle.c
@@ -2,12 +2,14 @@
 
 #include <string.h>
 
+#include <openssl/crypto.h>
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>
 #include <openssl/core_object.h>
 #include <openssl/params.h>
 
 #include "tpm2-provider-pkey.h"
+#include "tpm2-provider-types.h"
 
 typedef struct tpm2_handle_ctx_st TPM2_HANDLE_CTX;
 
@@ -222,7 +224,8 @@ tpm2_handle_load_index(TPM2_HANDLE_CTX *sctx, ESYS_TR object,
                        OSSL_CALLBACK *object_cb, void *object_cbarg)
 {
     TPM2B_NV_PUBLIC *metadata = NULL;
-    uint16_t read_len, read_max, data_len = 0;
+    uint16_t read_len, read_max = 0;
+    size_t data_len = 0;
     unsigned char *data = NULL;
     BIO *bufio;
     TSS2_RC r;
@@ -240,7 +243,7 @@ tpm2_handle_load_index(TPM2_HANDLE_CTX *sctx, ESYS_TR object,
     read_max = tpm2_max_nvindex_buffer(sctx->capability.properties);
     DBG("STORE/HANDLE LOAD index %u bytes (buffer %u bytes)\n", read_len, read_max);
 
-    if ((data = malloc(read_len)) == NULL)
+    if (!read_len || (data = malloc(read_len)) == NULL)
         goto final;
 
     while (read_len > 0) {
@@ -258,6 +261,7 @@ tpm2_handle_load_index(TPM2_HANDLE_CTX *sctx, ESYS_TR object,
         memcpy(data + data_len, buff->buffer, buff->size);
         read_len -= buff->size;
         data_len += buff->size;
+        OPENSSL_cleanse(buff, sizeof(TPM2B_MAX_NV_BUFFER));
         free(buff);
     }
 
@@ -303,10 +307,10 @@ tpm2_handle_load_index(TPM2_HANDLE_CTX *sctx, ESYS_TR object,
 
     OPENSSL_free(pem_name);
     OPENSSL_free(pem_header);
-    OPENSSL_free(der_data);
+    OPENSSL_clear_free(der_data, der_len);
     BIO_free(bufio);
 final:
-    free(data);
+    cleanse_free(data, data_len);
     free(metadata);
     return ret;
 }
@@ -421,4 +425,3 @@ const OSSL_DISPATCH tpm2_handle_store_functions[] = {
     { OSSL_FUNC_STORE_CLOSE, (void(*)(void))tpm2_handle_close },
     { 0, NULL }
 };
-


### PR DESCRIPTION
This pull request replace `free()` with `cleanse_free()` for Esys-allocated buffers.

### Targets

| Buffer | Contents | Func | File | 
| ------ | -------- | ---- | ---- |
| `actx->message` | RSA decrypted plaintext | `rsa_asymcipher_freectx` | `tpm2-provider-asymcipher-rsa.c` |
| `keyPrivate` | private key | `tpm2_load_external_key` | `tpm2-provider-cipher.c` |
| `outbuff` | decrypted plaintext (if decrypting) | `tpm2_cipher_process_buffer` | `tpm2-provider-cipher.c` 
| `outbuff` | decrypted plaintext (if decrypting) | `tpm2_cipher_update_stream` | `tpm2-provider-cipher.c` |
| `outPoint` | ECDH shared secret | `tpm2_keyexch_derive_kdf` | `tpm2-provider-keyexch.c` |
| `keyPrivate` | EC private key | `tpm2_ec_keymgmt_gen` | `tpm2-keymgmt-ec.c` |
| `keyPrivate` | RSA private key | `tpm2_rsa_keymgmt_gen` | `tpm2-keymgmt-rsa.c` |
| `buff`, `data`,`der_data` | DER/PEM read from NV index | `tpm2_handle_load_index` | `tpm2-provider-store-handle.c` |

### Test

I have confirmed that `make check` completed successfully.