### PR TITLE
tpm2-provider-cipher: Fix potential allocator–deallocator inconsistency for IV buffers

### DIFF
--- a/src/tpm2-provider-cipher.c
+++ b/src/tpm2-provider-cipher.c
@@ -10,6 +10,7 @@
 #include <tss2/tss2_mu.h>
 
 #include "tpm2-provider-pkey.h"
+#include "tpm2-provider-types.h"
 
 typedef struct tpm2_cipher_ctx_st TPM2_CIPHER_CTX;
 
@@ -54,7 +55,7 @@ tpm2_cipher_all_newctx(void *provctx,
     cctx->algorithm = algdef;
     cctx->block_size = block_bits/8;
     cctx->padding = 1;
-    cctx->ivector = OPENSSL_zalloc(sizeof(TPM2B_IV));
+    cctx->ivector = calloc(1, sizeof(TPM2B_IV));
     if (cctx->ivector == NULL) {
         OPENSSL_clear_free(cctx, sizeof(TPM2_CIPHER_CTX));
         return NULL;
@@ -90,7 +91,7 @@ tpm2_cipher_freectx(void *ctx)
         return;
 
     tpm2_esys_flush_context(cctx->esys_lock, cctx->esys_ctx, cctx->object);
-    OPENSSL_clear_free(cctx->ivector, sizeof(TPM2B_IV));
+    cleanse_free(cctx->ivector, sizeof(TPM2B_IV));
 
     OPENSSL_clear_free(cctx, sizeof(TPM2_CIPHER_CTX));
 }
@@ -259,7 +260,7 @@ tpm2_cipher_process_buffer(TPM2_CIPHER_CTX *cctx, int padded,
     r = encrypt_decrypt(cctx, &outbuff, &ivector);
     TPM2_CHECK_RC(cctx->core, r, TPM2_ERR_CANNOT_ENCRYPT, return 0);
 
-    OPENSSL_clear_free(cctx->ivector, sizeof(TPM2B_IV));
+    cleanse_free(cctx->ivector, sizeof(TPM2B_IV));
     cctx->ivector = ivector;
 
     cctx->buffer.size = 0;
@@ -388,7 +389,7 @@ tpm2_cipher_update_stream(void *ctx,
         r = encrypt_decrypt(cctx, &outbuff, &ivector);
         TPM2_CHECK_RC(cctx->core, r, TPM2_ERR_CANNOT_ENCRYPT, return 0);
 
-        OPENSSL_clear_free(cctx->ivector, sizeof(TPM2B_IV));
+        cleanse_free(cctx->ivector, sizeof(TPM2B_IV));
         cctx->ivector = ivector;
 
         if (outbuff->size < consume

--- a/src/tpm2-provider-types.c
+++ b/src/tpm2-provider-types.c
@@ -312,3 +312,13 @@ revmemcpy(void *dest, const void *src, size_t len)
     return dest;
 }
 
+// equivalent of OPENSSL_clear_free for TSS2 buffers
+void
+cleanse_free(void *p, size_t n)
+{
+    if (p) {
+        OPENSSL_cleanse(p, n);
+        free(p);
+    }
+}
+

--- a/src/tpm2-provider-types.h
+++ b/src/tpm2-provider-types.h
@@ -61,5 +61,8 @@ tpm2_param_set_BN_from_uint32(OSSL_PARAM *p, UINT32 num);
 void *
 revmemcpy(void *dest, const void *src, size_t len);
 
+void
+cleanse_free(void *p, size_t n);
+
 #endif /* TPM2_PROVIDER_TYPES_H */
 


### PR DESCRIPTION
Alternative solution to #163.