### PR TITLE
Added session functionality

### DIFF
--- a/src/tpm2-provider-asymcipher-rsa.c
+++ b/src/tpm2-provider-asymcipher-rsa.c
@@ -24,6 +24,7 @@ struct tpm2_rsa_asymcipher_ctx_st {
     tpm2_semaphore_t esys_lock;
     ESYS_CONTEXT *esys_ctx;
     TPM2_CAPABILITY capability;
+    ESYS_TR salt_key;
     TPMT_RSA_DECRYPT decrypt;
     /* TLS padding */
     unsigned int client_version;
@@ -52,6 +53,7 @@ static void
     actx->esys_lock = cprov->esys_lock;
     actx->esys_ctx = cprov->esys_ctx;
     actx->capability = cprov->capability;
+    actx->salt_key = cprov->salt_key;
     actx->decrypt.scheme = TPM2_ALG_RSAES;
     return actx;
 }
@@ -74,7 +76,8 @@ decrypt_message(TPM2_RSA_ASYMCIPHER_CTX *actx,
     TSS2_RC r;
     TPM2B_PUBLIC_KEY_RSA cipher;
     TPM2B_DATA label = { .size = 0 };
-
+    ESYS_TR session = ESYS_TR_NONE;
+    
     if (inlen > sizeof(cipher.buffer))
         return 0;
 
@@ -83,9 +86,15 @@ decrypt_message(TPM2_RSA_ASYMCIPHER_CTX *actx,
 
     if (!tpm2_semaphore_lock(actx->esys_lock))
         return 0;
+
+    if (!tpm2_start_auth_session(actx->esys_ctx, actx->salt_key, &session)) {
+        tpm2_semaphore_unlock(actx->esys_lock);
+        return 0;
+    }
     r = Esys_RSA_Decrypt(actx->esys_ctx, actx->pkey->object,
-                         ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                         session, ESYS_TR_NONE, ESYS_TR_NONE,
                          &cipher, &actx->decrypt, &label, &actx->message);
+    tpm2_end_auth_session(actx->esys_ctx, &session);
     tpm2_semaphore_unlock(actx->esys_lock);
     TPM2_CHECK_RC(actx->core, r, TPM2_ERR_CANNOT_DECRYPT, return 0);
 

--- a/src/tpm2-provider-cipher.c
+++ b/src/tpm2-provider-cipher.c
@@ -20,6 +20,7 @@ struct tpm2_cipher_ctx_st {
     tpm2_semaphore_t esys_lock;
     ESYS_CONTEXT *esys_ctx;
     TPM2_CAPABILITY capability;
+    ESYS_TR salt_key;
     ESYS_TR object;
     TPMT_SYM_DEF_OBJECT algorithm;
     size_t block_size;
@@ -53,6 +54,7 @@ tpm2_cipher_all_newctx(void *provctx,
     cctx->esys_lock = cprov->esys_lock;
     cctx->esys_ctx = cprov->esys_ctx;
     cctx->capability = cprov->capability;
+    cctx->salt_key = cprov->salt_key;
     cctx->algorithm = algdef;
     cctx->block_size = block_bits/8;
     cctx->padding = 1;
@@ -135,25 +137,33 @@ tpm2_load_external_key(TPM2_CIPHER_CTX *cctx, ESYS_TR parent,
     TPML_PCR_SELECTION creation_pcr = { .count = 0 };
     TPM2B_PUBLIC *keyPublic = NULL;
     TPM2B_PRIVATE *keyPrivate = NULL;
+    ESYS_TR session = ESYS_TR_NONE;
 
     if (!tpm2_semaphore_lock(cctx->esys_lock))
         return 0;
+
+    if (!tpm2_start_auth_session(cctx->esys_ctx, cctx->salt_key, &session))
+        goto error;
     /* older TPM2 chips do not support Esys_CreateLoaded */
     r = Esys_Create(cctx->esys_ctx, parent,
-                    ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                    session, ESYS_TR_NONE, ESYS_TR_NONE,
                     &inSensitive, &inPublic, &outside_info, &creation_pcr,
                     &keyPrivate, &keyPublic, NULL, NULL, NULL);
     if (!r) {
         r = Esys_Load(cctx->esys_ctx, parent,
-                      ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                      session, ESYS_TR_NONE, ESYS_TR_NONE,
                       keyPrivate, keyPublic, &cctx->object);
         free(keyPublic);
         cleanse_free(keyPrivate, sizeof(TPM2B_PRIVATE));
     }
+    tpm2_end_auth_session(cctx->esys_ctx, &session);
     tpm2_semaphore_unlock(cctx->esys_lock);
     TPM2_CHECK_RC(cctx->core, r, TPM2_ERR_CANNOT_CREATE_KEY, return 0);
 
     return 1;
+error:
+    tpm2_semaphore_unlock(cctx->esys_lock);
+    return 0;
 }
 
 static int
@@ -172,7 +182,7 @@ tpm2_cipher_init(TPM2_CIPHER_CTX *cctx,
 
         if (!tpm2_build_primary(cctx->core, cctx->esys_lock, cctx->esys_ctx,
                                 cctx->capability.algorithms,
-                                ESYS_TR_RH_NULL, NULL, &parent))
+                                ESYS_TR_RH_NULL, NULL, cctx->salt_key, &parent))
             return 0;
 
         res = tpm2_load_external_key(cctx, parent, key, keylen);
@@ -224,19 +234,26 @@ encrypt_decrypt(TPM2_CIPHER_CTX *cctx,
                 TPM2B_MAX_BUFFER **outbuff, TPM2B_IV **ivector)
 {
     TSS2_RC r;
-
+    ESYS_TR session = ESYS_TR_NONE;
+    
     if (!tpm2_semaphore_lock(cctx->esys_lock))
         return 0;
+
+    if (!tpm2_start_auth_session(cctx->esys_ctx, cctx->salt_key, &session)) {
+        tpm2_semaphore_unlock(cctx->esys_lock);
+        return 0;
+    }
     r = Esys_EncryptDecrypt2(cctx->esys_ctx, cctx->object,
-                             ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                             session, ESYS_TR_NONE, ESYS_TR_NONE,
                              &cctx->buffer, cctx->decrypt, TPM2_ALG_NULL,
                              cctx->ivector, outbuff, ivector);
     if ((r & 0xFFFF) == TPM2_RC_COMMAND_CODE) {
         r = Esys_EncryptDecrypt(cctx->esys_ctx, cctx->object,
-                                ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                                session, ESYS_TR_NONE, ESYS_TR_NONE,
                                 cctx->decrypt, TPM2_ALG_NULL, cctx->ivector,
                                 &cctx->buffer, outbuff, ivector);
     }
+    tpm2_end_auth_session(cctx->esys_ctx, &session);
     tpm2_semaphore_unlock(cctx->esys_lock);
 
     return r;

--- a/src/tpm2-provider-core.c
+++ b/src/tpm2-provider-core.c
@@ -167,3 +167,63 @@ tpm2_max_nvindex_buffer(const TPMS_CAPABILITY_DATA *caps)
 
     return max_nv_size;
 }
+
+int
+tpm2_create_salt_key(ESYS_CONTEXT *esys_ctx,
+                     const TPMS_CAPABILITY_DATA *algorithms,
+                     ESYS_TR *salt_key)
+{
+    TSS2_RC r;
+    TPM2B_PUBLIC inPublic = { 0 };
+    TPM2B_SENSITIVE_CREATE inSensitive = {
+        .size = 0,
+        .sensitive = {
+            .userAuth = { .size = 0 },
+            .data = { .size = 0 },
+        },
+    };
+    TPM2B_DATA outsideInfo = { .size = 0 };
+    TPML_PCR_SELECTION creationPCR = { .count = 0 };
+    ESYS_TR objectHandle = ESYS_TR_NONE;
+
+    inPublic.publicArea.nameAlg = TPM2_ALG_SHA256;
+    inPublic.publicArea.objectAttributes =
+        TPMA_OBJECT_FIXEDTPM | TPMA_OBJECT_FIXEDPARENT |
+        TPMA_OBJECT_SENSITIVEDATAORIGIN | TPMA_OBJECT_DECRYPT |
+        TPMA_OBJECT_NODA | TPMA_OBJECT_USERWITHAUTH;
+
+    if (tpm2_supports_algorithm(algorithms, TPM2_ALG_ECC)) {
+        inPublic.publicArea.type = TPM2_ALG_ECC;
+        inPublic.publicArea.parameters.eccDetail.symmetric.algorithm = TPM2_ALG_NULL;
+        inPublic.publicArea.parameters.eccDetail.scheme.scheme = TPM2_ALG_ECDH;
+        inPublic.publicArea.parameters.eccDetail.scheme.details.ecdh.hashAlg = TPM2_ALG_SHA256;
+        inPublic.publicArea.parameters.eccDetail.curveID = TPM2_ECC_NIST_P256;
+        inPublic.publicArea.parameters.eccDetail.kdf.scheme = TPM2_ALG_NULL;
+        inPublic.publicArea.unique.ecc.x.size = 0;
+        inPublic.publicArea.unique.ecc.y.size = 0;
+    } else {
+        inPublic.publicArea.type = TPM2_ALG_RSA;
+        inPublic.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM2_ALG_NULL;
+        inPublic.publicArea.parameters.rsaDetail.scheme.scheme = TPM2_ALG_OAEP;
+        inPublic.publicArea.parameters.rsaDetail.scheme.details.oaep.hashAlg = TPM2_ALG_SHA256;
+        inPublic.publicArea.parameters.rsaDetail.keyBits = 2048;
+        inPublic.publicArea.parameters.rsaDetail.exponent = 0;
+        inPublic.publicArea.unique.rsa.size = 0;
+    }
+
+    r = Esys_CreatePrimary(esys_ctx,
+                           ESYS_TR_RH_NULL,
+                           ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                           &inSensitive, &inPublic,
+                           &outsideInfo, &creationPCR,
+                           &objectHandle,
+                           NULL, NULL, NULL, NULL);
+    if (r != TSS2_RC_SUCCESS) {
+        *salt_key = ESYS_TR_NONE;
+        return 0;
+    }
+
+    *salt_key = objectHandle;
+    return 1;
+}
+

--- a/src/tpm2-provider-core.c
+++ b/src/tpm2-provider-core.c
@@ -227,3 +227,52 @@ tpm2_create_salt_key(ESYS_CONTEXT *esys_ctx,
     return 1;
 }
 
+int
+tpm2_start_auth_session(ESYS_CONTEXT *esys_ctx, ESYS_TR salt_key,
+                        ESYS_TR *session)
+{
+    TSS2_RC r;
+    TPMT_SYM_DEF symmetric = {
+        .algorithm = TPM2_ALG_AES,
+        .keyBits = { .aes = 128 },
+        .mode = { .aes = TPM2_ALG_CFB },
+    };
+
+    r = Esys_StartAuthSession(esys_ctx,
+                              salt_key,
+                              ESYS_TR_NONE,
+                              ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                              NULL,
+                              TPM2_SE_HMAC,
+                              &symmetric,
+                              TPM2_ALG_SHA256,
+                              session);
+    if (r != TSS2_RC_SUCCESS) {
+        *session = ESYS_TR_NONE;
+        return 0;
+    }
+
+    r = Esys_TRSess_SetAttributes(esys_ctx, *session,
+                                  TPMA_SESSION_DECRYPT |
+                                  TPMA_SESSION_ENCRYPT |
+                                  TPMA_SESSION_CONTINUESESSION,
+                                  TPMA_SESSION_DECRYPT |
+                                  TPMA_SESSION_ENCRYPT |
+                                  TPMA_SESSION_CONTINUESESSION);
+    if (r != TSS2_RC_SUCCESS) {
+        Esys_FlushContext(esys_ctx, *session);
+        *session = ESYS_TR_NONE;
+        return 0;
+    }
+
+    return 1;
+}
+
+void
+tpm2_end_auth_session(ESYS_CONTEXT *esys_ctx, ESYS_TR *session)
+{
+    if (*session != ESYS_TR_NONE) {
+        Esys_FlushContext(esys_ctx, *session);
+        *session = ESYS_TR_NONE;
+    }
+}

--- a/src/tpm2-provider-decoder-tss2.c
+++ b/src/tpm2-provider-decoder-tss2.c
@@ -23,6 +23,7 @@ struct tpm2_tss2_decoder_ctx_st {
     tpm2_semaphore_t esys_lock;
     ESYS_CONTEXT *esys_ctx;
     TPM2_CAPABILITY capability;
+    ESYS_TR salt_key;
     TPM2B_DIGEST parentAuth;
 };
 
@@ -46,6 +47,7 @@ tpm2_tss2_decoder_newctx(void *provctx)
     dctx->esys_lock = cprov->esys_lock;
     dctx->esys_ctx = cprov->esys_ctx;
     dctx->capability = cprov->capability;
+    dctx->salt_key = cprov->salt_key;
     return dctx;
 }
 
@@ -79,15 +81,22 @@ decode_privkey(TPM2_TSS2_DECODER_CTX *dctx, TPM2_PKEY *pkey,
             DBG("TSS2 DECODER LOAD parent: primary 0x%x\n", TPM2_RH_OWNER);
             if (!tpm2_build_primary(pkey->core, pkey->esys_lock, pkey->esys_ctx,
                                     pkey->capability.algorithms,
-                                    ESYS_TR_RH_OWNER, &dctx->parentAuth, &parent))
+                                    ESYS_TR_RH_OWNER, &dctx->parentAuth, pkey->salt_key, &parent))
                 goto error1;
         }
 
         if (!tpm2_semaphore_lock(pkey->esys_lock))
             goto error1;
+
+        ESYS_TR session = ESYS_TR_NONE;
+        if (!tpm2_start_auth_session(pkey->esys_ctx, pkey->salt_key, &session)) {
+            tpm2_semaphore_unlock(pkey->esys_lock);
+            goto error1;
+        }
         r = Esys_Load(pkey->esys_ctx, parent,
-                      ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                      session, ESYS_TR_NONE, ESYS_TR_NONE,
                       &pkey->data.priv, &pkey->data.pub, &pkey->object);
+        tpm2_end_auth_session(pkey->esys_ctx, &session);
 
         if (pkey->data.parent && pkey->data.parent != TPM2_RH_OWNER)
             Esys_TR_Close(pkey->esys_ctx, &parent);
@@ -171,6 +180,7 @@ tpm2_tss2_decoder_decode(void *ctx, OSSL_CORE_BIO *cin, int selection,
     pkey->esys_lock = dctx->esys_lock;
     pkey->esys_ctx = dctx->esys_ctx;
     pkey->capability = dctx->capability;
+    pkey->salt_key = dctx->salt_key;
     pkey->object = ESYS_TR_NONE;
 
     if (selection == 0 || (selection & OSSL_KEYMGMT_SELECT_ALL) != 0)

--- a/src/tpm2-provider-digest.c
+++ b/src/tpm2-provider-digest.c
@@ -16,6 +16,7 @@ tpm2_hash_sequence_init(TPM2_HASH_SEQUENCE *seq,
     seq->core = cprov->core;
     seq->esys_lock = cprov->esys_lock;
     seq->esys_ctx = cprov->esys_ctx;
+    seq->salt_key = cprov->salt_key;
     seq->algorithm = algin;
     seq->handle = ESYS_TR_NONE;
 }
@@ -36,6 +37,7 @@ tpm2_hash_sequence_dup(TPM2_HASH_SEQUENCE *seq, const TPM2_HASH_SEQUENCE *src)
     seq->core = src->core;
     seq->esys_lock = src->esys_lock;
     seq->esys_ctx = src->esys_ctx;
+    seq->salt_key = src->salt_key;
     seq->algorithm = src->algorithm;
 
     if (src->handle != ESYS_TR_NONE) {
@@ -84,6 +86,7 @@ tpm2_hash_sequence_update(TPM2_HASH_SEQUENCE *seq,
                           const unsigned char *data, size_t datalen)
 {
     TSS2_RC r;
+    ESYS_TR session = ESYS_TR_NONE;
 
     if (data == NULL)
         return 1;
@@ -104,8 +107,14 @@ tpm2_hash_sequence_update(TPM2_HASH_SEQUENCE *seq,
 
         if (!tpm2_semaphore_lock(seq->esys_lock))
             return 0;
+
+        if (!tpm2_start_auth_session(seq->esys_ctx, seq->salt_key, &session)) {
+            tpm2_semaphore_unlock(seq->esys_lock);
+            return 0;
+        }
         r = Esys_SequenceUpdate(seq->esys_ctx, seq->handle,
-                                ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE, &seq->buffer);
+                                session, ESYS_TR_NONE, ESYS_TR_NONE, &seq->buffer);
+        tpm2_end_auth_session(seq->esys_ctx, &session);
         tpm2_semaphore_unlock(seq->esys_lock);
         seq->buffer.size = 0;
         TPM2_CHECK_RC(seq->core, r, TPM2_ERR_CANNOT_HASH, return 0);
@@ -119,22 +128,31 @@ tpm2_hash_sequence_complete(TPM2_HASH_SEQUENCE *seq,
                             TPM2B_DIGEST **digest, TPMT_TK_HASHCHECK **validation)
 {
     TSS2_RC r;
-
-    if (seq->buffer.size > 0) {
-        if (!tpm2_semaphore_lock(seq->esys_lock))
-            return 0;
-        r = Esys_SequenceUpdate(seq->esys_ctx, seq->handle,
-                                ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE, &seq->buffer);
-        tpm2_semaphore_unlock(seq->esys_lock);
-        seq->buffer.size = 0;
-        TPM2_CHECK_RC(seq->core, r, TPM2_ERR_CANNOT_HASH, return 0);
-    }
-
+    ESYS_TR session = ESYS_TR_NONE;
+    
     if (!tpm2_semaphore_lock(seq->esys_lock))
         return 0;
+
+    if (!tpm2_start_auth_session(seq->esys_ctx, seq->salt_key, &session)) {
+        tpm2_semaphore_unlock(seq->esys_lock);
+        return 0;
+    }
+
+    if (seq->buffer.size > 0) {
+        r = Esys_SequenceUpdate(seq->esys_ctx, seq->handle,
+                                session, ESYS_TR_NONE, ESYS_TR_NONE, &seq->buffer);
+        seq->buffer.size = 0;
+        if (r != TPM2_RC_SUCCESS) {
+            tpm2_end_auth_session(seq->esys_ctx, &session);
+            tpm2_semaphore_unlock(seq->esys_lock);
+            TPM2_CHECK_RC(seq->core, r, TPM2_ERR_CANNOT_HASH, return 0);
+        }
+    }
+
     r = Esys_SequenceComplete(seq->esys_ctx, seq->handle,
-                              ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                              session, ESYS_TR_NONE, ESYS_TR_NONE,
                               NULL, ESYS_TR_RH_OWNER, digest, validation);
+    tpm2_end_auth_session(seq->esys_ctx, &session);
     tpm2_semaphore_unlock(seq->esys_lock);
     TPM2_CHECK_RC(seq->core, r, TPM2_ERR_CANNOT_HASH, return 0);
 

--- a/src/tpm2-provider-digest.h
+++ b/src/tpm2-provider-digest.h
@@ -12,6 +12,7 @@ struct tpm2_hash_sequence_st {
     const OSSL_CORE_HANDLE *core;
     tpm2_semaphore_t esys_lock;
     ESYS_CONTEXT *esys_ctx;
+    ESYS_TR salt_key;
     TPM2_ALG_ID algorithm;
     ESYS_TR handle;
     TPM2B_MAX_BUFFER buffer;

--- a/src/tpm2-provider-keyexch.c
+++ b/src/tpm2-provider-keyexch.c
@@ -18,6 +18,7 @@ struct tpm2_keyexch_ctx_st {
     OSSL_LIB_CTX *libctx;
     tpm2_semaphore_t esys_lock;
     ESYS_CONTEXT *esys_ctx;
+    ESYS_TR salt_key;
     TPM2_PKEY *pkey;
     TPM2B_ECC_POINT peer;
     /* KDF settings */
@@ -51,6 +52,7 @@ tpm2_keyexch_newctx(void *provctx)
     kexc->libctx = cprov->libctx;
     kexc->esys_lock = cprov->esys_lock;
     kexc->esys_ctx = cprov->esys_ctx;
+    kexc->salt_key = cprov->salt_key;
     return kexc;
 }
 
@@ -100,6 +102,7 @@ tpm2_keyexch_derive_kdf(TPM2_KEYEXCH_CTX *kexc, unsigned char *secret,
     EVP_KDF_CTX *kctx = NULL;
     OSSL_PARAM params[4], *p = params;
     int res = 0;
+    ESYS_TR session = ESYS_TR_NONE;
 
     if (secret == NULL) {
         *secretlen = kexc->kdf_outlen;
@@ -114,9 +117,15 @@ tpm2_keyexch_derive_kdf(TPM2_KEYEXCH_CTX *kexc, unsigned char *secret,
 
     if (!tpm2_semaphore_lock(kexc->esys_lock))
         return 0;
+
+    if (!tpm2_start_auth_session(kexc->esys_ctx, kexc->salt_key, &session)) {
+        tpm2_semaphore_unlock(kexc->esys_lock);
+        return 0;
+    }
     r = Esys_ECDH_ZGen(kexc->esys_ctx, kexc->pkey->object,
-                       ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                       session, ESYS_TR_NONE, ESYS_TR_NONE,
                        &kexc->peer, &outPoint);
+    tpm2_end_auth_session(kexc->esys_ctx, &session);
     tpm2_semaphore_unlock(kexc->esys_lock);
     TPM2_CHECK_RC(kexc->core, r, TPM2_ERR_CANNOT_GENERATE, return 0);
 
@@ -148,14 +157,21 @@ tpm2_keyexch_derive_plain(TPM2_KEYEXCH_CTX *kexc, unsigned char *secret,
 {
     TPM2B_ECC_POINT *outPoint = NULL;
     TSS2_RC r;
+    ESYS_TR session = ESYS_TR_NONE;
 
     DBG("KEYEXCH DERIVE plain\n");
 
     if (!tpm2_semaphore_lock(kexc->esys_lock))
         return 0;
+
+    if (!tpm2_start_auth_session(kexc->esys_ctx, kexc->salt_key, &session)) {
+        tpm2_semaphore_unlock(kexc->esys_lock);
+        return 0;
+    }
     r = Esys_ECDH_ZGen(kexc->esys_ctx, kexc->pkey->object,
-                       ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                       session, ESYS_TR_NONE, ESYS_TR_NONE,
                        &kexc->peer, &outPoint);
+    tpm2_end_auth_session(kexc->esys_ctx, &session);
     tpm2_semaphore_unlock(kexc->esys_lock);
     TPM2_CHECK_RC(kexc->core, r, TPM2_ERR_CANNOT_GENERATE, return 0);
 

--- a/src/tpm2-provider-keymgmt-ec.c
+++ b/src/tpm2-provider-keymgmt-ec.c
@@ -45,6 +45,7 @@ struct tpm2_ecgen_ctx_st {
     tpm2_semaphore_t esys_lock;
     ESYS_CONTEXT *esys_ctx;
     TPM2_CAPABILITY capability;
+    ESYS_TR salt_key;
     TPM2_HANDLE parentHandle;
     TPM2B_DIGEST parentAuth;
     TPM2B_PUBLIC inPublic;
@@ -86,6 +87,7 @@ tpm2_ec_keymgmt_new(void *provctx)
     pkey->esys_lock = cprov->esys_lock;
     pkey->esys_ctx = cprov->esys_ctx;
     pkey->capability = cprov->capability;
+    pkey->salt_key = cprov->salt_key;
     pkey->object = ESYS_TR_NONE;
 
     pkey->data.pub = keyTemplate;
@@ -110,6 +112,7 @@ tpm2_ec_keymgmt_gen_init(void *provctx, int selection, const OSSL_PARAM params[]
     gen->esys_lock = cprov->esys_lock;
     gen->esys_ctx = cprov->esys_ctx;
     gen->capability = cprov->capability;
+    gen->salt_key = cprov->salt_key;
 
     gen->inPublic = keyTemplate;
     /* same default attributes as in tpm2_create */
@@ -205,6 +208,7 @@ tpm2_ec_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
 {
     TPM2_ECGEN_CTX *gen = ctx;
     ESYS_TR parent = ESYS_TR_NONE;
+    ESYS_TR session = ESYS_TR_NONE;
     TPM2B_PUBLIC *keyPublic = NULL;
     TPM2B_PRIVATE *keyPrivate = NULL;
     TPM2_PKEY *pkey = NULL;
@@ -222,6 +226,7 @@ tpm2_ec_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
     pkey->esys_lock = gen->esys_lock;
     pkey->esys_ctx = gen->esys_ctx;
     pkey->capability = gen->capability;
+    pkey->salt_key = gen->salt_key;
 
     if (gen->inSensitive.sensitive.userAuth.size == 0)
         pkey->data.emptyAuth = 1;
@@ -237,7 +242,7 @@ tpm2_ec_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
         DBG("EC GEN parent: primary 0x%x\n", TPM2_RH_OWNER);
         if (!tpm2_build_primary(pkey->core, pkey->esys_lock, pkey->esys_ctx,
                                 pkey->capability.algorithms,
-                                ESYS_TR_RH_OWNER, &gen->parentAuth, &parent))
+                                ESYS_TR_RH_OWNER, &gen->parentAuth, gen->salt_key, &parent))
             goto error1;
     }
 
@@ -246,9 +251,12 @@ tpm2_ec_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
 
     if (!tpm2_semaphore_lock(gen->esys_lock))
         return 0;
+
+    if (!tpm2_start_auth_session(gen->esys_ctx, gen->salt_key, &session))
+        goto error1;
     /* older TPM2 chips do not support Esys_CreateLoaded */
     r = Esys_Create(gen->esys_ctx, parent,
-                    ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                    session, ESYS_TR_NONE, ESYS_TR_NONE,
                     &gen->inSensitive, &gen->inPublic, &outside_info, &creation_pcr,
                     &keyPrivate, &keyPublic, NULL, NULL, NULL);
     TPM2_CHECK_RC(gen->core, r, TPM2_ERR_CANNOT_CREATE_KEY, goto error1);
@@ -258,10 +266,11 @@ tpm2_ec_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
     pkey->data.priv = *keyPrivate;
 
     r = Esys_Load(gen->esys_ctx, parent,
-                  ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                  session, ESYS_TR_NONE, ESYS_TR_NONE,
                   keyPrivate, keyPublic, &pkey->object);
     free(keyPublic);
     cleanse_free(keyPrivate, sizeof(TPM2B_PRIVATE));
+    tpm2_end_auth_session(gen->esys_ctx, &session);
     TPM2_CHECK_RC(gen->core, r, TPM2_ERR_CANNOT_CREATE_KEY, goto error1);
 
     if (gen->parentHandle && gen->parentHandle != TPM2_RH_OWNER)
@@ -278,6 +287,7 @@ tpm2_ec_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
 error2:
     Esys_FlushContext(gen->esys_ctx, pkey->object);
 error1:
+    tpm2_end_auth_session(gen->esys_ctx, &session);
     tpm2_semaphore_unlock(gen->esys_lock);
     OPENSSL_clear_free(pkey, sizeof(TPM2_PKEY));
     return NULL;

--- a/src/tpm2-provider-keymgmt-rsa.c
+++ b/src/tpm2-provider-keymgmt-rsa.c
@@ -45,6 +45,7 @@ struct tpm2_rsagen_ctx_st {
     tpm2_semaphore_t esys_lock;
     ESYS_CONTEXT *esys_ctx;
     TPM2_CAPABILITY capability;
+    ESYS_TR salt_key;
     TPM2_HANDLE parentHandle;
     TPM2B_DIGEST parentAuth;
     TPM2B_PUBLIC inPublic;
@@ -86,6 +87,7 @@ tpm2_rsa_keymgmt_new(void *provctx)
     pkey->esys_lock = cprov->esys_lock;
     pkey->esys_ctx = cprov->esys_ctx;
     pkey->capability = cprov->capability;
+    pkey->salt_key = cprov->salt_key;
     pkey->object = ESYS_TR_NONE;
 
     pkey->data.pub = keyTemplate;
@@ -108,6 +110,7 @@ tpm2_create_rsagen_ctx(void *provctx)
     gen->esys_lock = cprov->esys_lock;
     gen->esys_ctx = cprov->esys_ctx;
     gen->capability = cprov->capability;
+    gen->salt_key = cprov->salt_key;
     return gen;
 }
 
@@ -246,6 +249,7 @@ tpm2_rsa_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
 {
     TPM2_RSAGEN_CTX *gen = ctx;
     ESYS_TR parent = ESYS_TR_NONE;
+    ESYS_TR session = ESYS_TR_NONE;
     TPM2B_PUBLIC *keyPublic = NULL;
     TPM2B_PRIVATE *keyPrivate = NULL;
     TPM2_PKEY *pkey = NULL;
@@ -264,6 +268,7 @@ tpm2_rsa_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
     pkey->esys_lock = gen->esys_lock;
     pkey->esys_ctx = gen->esys_ctx;
     pkey->capability = gen->capability;
+    pkey->salt_key = gen->salt_key;
 
     if (gen->inSensitive.sensitive.userAuth.size == 0)
         pkey->data.emptyAuth = 1;
@@ -279,7 +284,7 @@ tpm2_rsa_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
         DBG("RSA GEN parent: primary 0x%x\n", TPM2_RH_OWNER);
         if (!tpm2_build_primary(pkey->core, pkey->esys_lock, pkey->esys_ctx,
                                 pkey->capability.algorithms,
-                                ESYS_TR_RH_OWNER, &gen->parentAuth, &parent))
+                                ESYS_TR_RH_OWNER, &gen->parentAuth, gen->salt_key, &parent))
             goto error1;
     }
 
@@ -288,9 +293,12 @@ tpm2_rsa_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
 
     if (!tpm2_semaphore_lock(gen->esys_lock))
         goto error1;
+
+    if (!tpm2_start_auth_session(gen->esys_ctx, gen->salt_key, &session))
+        goto error2;
     /* older TPM2 chips do not support Esys_CreateLoaded */
     r = Esys_Create(gen->esys_ctx, parent,
-                    ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                    session, ESYS_TR_NONE, ESYS_TR_NONE,
                     &gen->inSensitive, &gen->inPublic, &outside_info, &creation_pcr,
                     &keyPrivate, &keyPublic, NULL, NULL, NULL);
     TPM2_CHECK_RC(gen->core, r, TPM2_ERR_CANNOT_CREATE_KEY, goto error2);
@@ -300,10 +308,11 @@ tpm2_rsa_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
     pkey->data.priv = *keyPrivate;
 
     r = Esys_Load(gen->esys_ctx, parent,
-                  ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                  session, ESYS_TR_NONE, ESYS_TR_NONE,
                   keyPrivate, keyPublic, &pkey->object);
     free(keyPublic);
     cleanse_free(keyPrivate, sizeof(TPM2B_PRIVATE));
+    tpm2_end_auth_session(gen->esys_ctx, &session);
     TPM2_CHECK_RC(gen->core, r, TPM2_ERR_CANNOT_CREATE_KEY, goto error2);
 
     if (gen->parentHandle && gen->parentHandle != TPM2_RH_OWNER)
@@ -320,6 +329,7 @@ tpm2_rsa_keymgmt_gen(void *ctx, OSSL_CALLBACK *cb, void *cbarg)
 error3:
     Esys_FlushContext(gen->esys_ctx, pkey->object);
 error2:
+    tpm2_end_auth_session(gen->esys_ctx, &session);
     tpm2_semaphore_unlock(gen->esys_lock);
 error1:
     OPENSSL_clear_free(pkey, sizeof(TPM2_PKEY));

--- a/src/tpm2-provider-pkey.c
+++ b/src/tpm2-provider-pkey.c
@@ -302,9 +302,10 @@ error1:
 int
 tpm2_build_primary(const OSSL_CORE_HANDLE *core, tpm2_semaphore_t esys_lock, ESYS_CONTEXT *esys_ctx,
                    const TPMS_CAPABILITY_DATA *algorithms, ESYS_TR hierarchy,
-                   const TPM2B_DIGEST *auth, ESYS_TR *object)
+                   const TPM2B_DIGEST *auth, ESYS_TR salt_key, ESYS_TR *object)
 {
     const TPM2B_PUBLIC *primaryTemplate = NULL;
+    ESYS_TR session = ESYS_TR_NONE;
     TSS2_RC r;
 
     if (!tpm2_semaphore_lock(esys_lock))
@@ -322,11 +323,17 @@ tpm2_build_primary(const OSSL_CORE_HANDLE *core, tpm2_semaphore_t esys_lock, ESY
         goto error;
     }
 
+    if (!tpm2_start_auth_session(esys_ctx, salt_key, &session)) {
+        TPM2_ERROR_raise(core, TPM2_ERR_CANNOT_START_SESSION);
+        goto error;
+    }
+
     r = Esys_CreatePrimary(esys_ctx, hierarchy,
-                           ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                           session, ESYS_TR_NONE, ESYS_TR_NONE,
                            &primarySensitive, primaryTemplate, &allOutsideInfo,
                            &allCreationPCR,
                            object, NULL, NULL, NULL, NULL);
+    tpm2_end_auth_session(esys_ctx, &session);
     if (r == 0x000009a2) {
         TPM2_ERROR_raise(core, TPM2_ERR_AUTHORIZATION_FAILURE);
         goto error;
@@ -336,6 +343,7 @@ tpm2_build_primary(const OSSL_CORE_HANDLE *core, tpm2_semaphore_t esys_lock, ESY
     tpm2_semaphore_unlock(esys_lock);
     return 1;
 error:
+    tpm2_end_auth_session(esys_ctx, &session);
     tpm2_semaphore_unlock(esys_lock);
     return 0;
 }

--- a/src/tpm2-provider-pkey.h
+++ b/src/tpm2-provider-pkey.h
@@ -34,7 +34,7 @@ tpm2_load_parent(const OSSL_CORE_HANDLE *core, tpm2_semaphore_t esys_lock, ESYS_
 int
 tpm2_build_primary(const OSSL_CORE_HANDLE *core, tpm2_semaphore_t esys_lock, ESYS_CONTEXT *esys_ctx,
                    const TPMS_CAPABILITY_DATA *capability, ESYS_TR hierarchy,
-                   const TPM2B_DIGEST *auth, ESYS_TR *object);
+                   const TPM2B_DIGEST *auth, ESYS_TR salt_key, ESYS_TR *object);
 
 const char *
 tpm2_openssl_type(TPM2_KEYDATA *keydata);

--- a/src/tpm2-provider-signature.c
+++ b/src/tpm2-provider-signature.c
@@ -20,6 +20,7 @@ struct tpm2_signature_ctx_st {
             const OSSL_CORE_HANDLE *core;
             tpm2_semaphore_t esys_lock;
             ESYS_CONTEXT *esys_ctx;
+            ESYS_TR salt_key;
         };
     };
     TPM2_CAPABILITY capability;
@@ -329,6 +330,7 @@ tpm2_signature_sign(void *ctx, unsigned char *sig, size_t *siglen, size_t sigsiz
     TPM2_SIGNATURE_CTX *sctx = ctx;
     TPM2B_DIGEST digest;
     TSS2_RC r;
+    ESYS_TR session = ESYS_TR_NONE;
 
     TPMT_TK_HASHCHECK empty_validation = {
         .tag = TPM2_ST_HASHCHECK,
@@ -357,9 +359,15 @@ tpm2_signature_sign(void *ctx, unsigned char *sig, size_t *siglen, size_t sigsiz
 
     if (!tpm2_semaphore_lock(sctx->esys_lock))
         return 0;
+
+    if (!tpm2_start_auth_session(sctx->esys_ctx, sctx->salt_key, &session)) {
+        tpm2_semaphore_unlock(sctx->esys_lock);
+        return 0;
+    }
     r = Esys_Sign(sctx->esys_ctx, sctx->pkey->object,
-                  ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                  session, ESYS_TR_NONE, ESYS_TR_NONE,
                   &digest, &sctx->signScheme, &empty_validation, &sctx->signature);
+    tpm2_end_auth_session(sctx->esys_ctx, &session);
     tpm2_semaphore_unlock(sctx->esys_lock);
     TPM2_CHECK_RC(sctx->core, r, TPM2_ERR_CANNOT_SIGN, return 0);
 
@@ -427,6 +435,7 @@ digest_sign_calculate(TPM2_SIGNATURE_CTX *sctx)
     TSS2_RC r;
     TPM2B_DIGEST *digest = NULL;
     TPMT_TK_HASHCHECK *validation = NULL;
+    ESYS_TR session = ESYS_TR_NONE;
 
     DBG("SIGN DIGEST_SIGN_CALCULATE\n");
     if (!tpm2_hash_sequence_complete((TPM2_HASH_SEQUENCE *)sctx, &digest, &validation))
@@ -437,11 +446,19 @@ digest_sign_calculate(TPM2_SIGNATURE_CTX *sctx)
 
     if (!tpm2_semaphore_lock(sctx->esys_lock))
         return 0;
+
+    if (!tpm2_start_auth_session(sctx->esys_ctx, sctx->salt_key, &session)) {
+        free(digest);
+        free(validation);
+        tpm2_semaphore_unlock(sctx->esys_lock);
+        return 0;
+    }
     r = Esys_Sign(sctx->esys_ctx, sctx->pkey->object,
-                  ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                  session, ESYS_TR_NONE, ESYS_TR_NONE,
                   digest, &sctx->signScheme, validation, &sctx->signature);
     free(digest);
     free(validation);
+    tpm2_end_auth_session(sctx->esys_ctx, &session);
     tpm2_semaphore_unlock(sctx->esys_lock);
     TPM2_CHECK_RC(sctx->core, r, TPM2_ERR_CANNOT_SIGN, return 0);
 
@@ -478,6 +495,7 @@ tpm2_signature_digest_sign(void *ctx, unsigned char *sig, size_t *siglen,
     TPM2_SIGNATURE_CTX *sctx = ctx;
     TPM2B_DIGEST *digest = NULL;
     TPMT_TK_HASHCHECK *validation = NULL;
+    ESYS_TR session = ESYS_TR_NONE;
 
     if (sig == NULL) {
         DBG("SIGN DIGEST_SIGN estimate\n");
@@ -502,11 +520,19 @@ tpm2_signature_digest_sign(void *ctx, unsigned char *sig, size_t *siglen,
 
     if (!tpm2_semaphore_lock(sctx->esys_lock))
         return 0;
+
+    if (!tpm2_start_auth_session(sctx->esys_ctx, sctx->salt_key, &session)) {
+        free(digest);
+        free(validation);
+        tpm2_semaphore_unlock(sctx->esys_lock);
+        return 0;
+    }
     r = Esys_Sign(sctx->esys_ctx, sctx->pkey->object,
-                  ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                  session, ESYS_TR_NONE, ESYS_TR_NONE,
                   digest, &sctx->signScheme, validation, &sctx->signature);
     free(digest);
     free(validation);
+    tpm2_end_auth_session(sctx->esys_ctx, &session);
     tpm2_semaphore_unlock(sctx->esys_lock);
     TPM2_CHECK_RC(sctx->core, r, TPM2_ERR_CANNOT_SIGN, return 0);
 

--- a/src/tpm2-provider-store-handle.c
+++ b/src/tpm2-provider-store-handle.c
@@ -18,6 +18,7 @@ struct tpm2_handle_ctx_st {
     tpm2_semaphore_t esys_lock;
     ESYS_CONTEXT *esys_ctx;
     TPM2_CAPABILITY capability;
+    ESYS_TR salt_key;
     int has_pass;
     TPM2_HANDLE handle;
     BIO *bio;
@@ -47,6 +48,7 @@ tpm2_handle_open(void *provctx, const char *uri)
     ctx->esys_lock = cprov->esys_lock;
     ctx->esys_ctx = cprov->esys_ctx;
     ctx->capability = cprov->capability;
+    ctx->salt_key = cprov->salt_key;
 
     if ((baseuri = OPENSSL_strdup(uri)) == NULL)
         goto error1;
@@ -99,6 +101,7 @@ tpm2_handle_attach(void *provctx, OSSL_CORE_BIO *cin)
     ctx->esys_lock = cprov->esys_lock;
     ctx->esys_ctx = cprov->esys_ctx;
     ctx->capability = cprov->capability;
+    ctx->salt_key = cprov->salt_key;
 
     if ((ctx->bio = BIO_new_from_core_bio(cprov->libctx, cin)) == NULL)
         goto error;
@@ -177,6 +180,7 @@ tpm2_handle_load_pkey(TPM2_HANDLE_CTX *sctx, ESYS_TR object,
     pkey->esys_lock = sctx->esys_lock;
     pkey->esys_ctx = sctx->esys_ctx;
     pkey->capability = sctx->capability;
+    pkey->salt_key = sctx->salt_key;
     pkey->object = object;
 
     if (!tpm2_semaphore_lock(sctx->esys_lock))
@@ -249,12 +253,18 @@ tpm2_handle_load_index(TPM2_HANDLE_CTX *sctx, ESYS_TR object,
     while (read_len > 0) {
         uint16_t bytes_to_read = read_len < read_max ? read_len : read_max;
         TPM2B_MAX_NV_BUFFER *buff = NULL;
+        ESYS_TR session = ESYS_TR_NONE;
 
         if (!tpm2_semaphore_lock(sctx->esys_lock))
             goto final;
+        if (!tpm2_start_auth_session(sctx->esys_ctx, sctx->salt_key, &session)) {
+            tpm2_semaphore_unlock(sctx->esys_lock);
+            goto final;
+        }
         r = Esys_NV_Read(sctx->esys_ctx, object, object,
-                         ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                         session, ESYS_TR_NONE, ESYS_TR_NONE,
                          bytes_to_read, data_len, &buff);
+        tpm2_end_auth_session(sctx->esys_ctx, &session);
         tpm2_semaphore_unlock(sctx->esys_lock);
         TPM2_CHECK_RC(sctx->core, r, TPM2_ERR_CANNOT_LOAD_KEY, goto final);
 

--- a/src/tpm2-provider.c
+++ b/src/tpm2-provider.c
@@ -359,6 +359,8 @@ tpm2_teardown(void *provctx)
     TSS2_RC r;
 
     DBG("PROVIDER TEARDOWN\n");
+    if (cprov->salt_key != ESYS_TR_NONE)
+        Esys_FlushContext(cprov->esys_ctx, cprov->salt_key);
     free(cprov->capability.properties);
     free(cprov->capability.algorithms);
     free(cprov->capability.commands);
@@ -525,6 +527,12 @@ OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
                            TPM2_CAP_COMMANDS, 0, TPM2_MAX_CAP_CC,
                            NULL, &cprov->capability.commands);
     TPM2_CHECK_RC(cprov->core, r, TPM2_ERR_CANNOT_GET_CAPABILITY, goto err4);
+
+    if (!tpm2_create_salt_key(cprov->esys_ctx, cprov->capability.algorithms,
+                              &cprov->salt_key)) {
+        TPM2_ERROR_raise(cprov->core, TPM2_ERR_CANNOT_START_SESSION);
+        goto err4;
+    }
 
     *out = tpm2_dispatch_table;
     *provctx = cprov;

--- a/src/tpm2-provider.h
+++ b/src/tpm2-provider.h
@@ -30,6 +30,7 @@ struct tpm2_provider_ctx_st {
     tpm2_semaphore_t esys_lock;
     ESYS_CONTEXT *esys_ctx;
     TPM2_CAPABILITY capability;
+    ESYS_TR salt_key;
 };
 
 typedef enum {
@@ -58,6 +59,7 @@ typedef struct {
     tpm2_semaphore_t esys_lock;
     ESYS_CONTEXT *esys_ctx;
     TPM2_CAPABILITY capability;
+    ESYS_TR salt_key;
     ESYS_TR object;
 } TPM2_PKEY;
 
@@ -88,7 +90,8 @@ enum {
     TPM2_ERR_VERIFICATION_FAILED,
     TPM2_ERR_CANNOT_ENCRYPT,
     TPM2_ERR_CANNOT_DECRYPT,
-    TPM2_ERR_CANNOT_DUPLICATE
+    TPM2_ERR_CANNOT_DUPLICATE,
+    TPM2_ERR_CANNOT_START_SESSION
 };
 
 int
@@ -151,6 +154,16 @@ tpm2_supports_command(const TPMS_CAPABILITY_DATA *caps, TPM2_CC command);
 
 uint16_t
 tpm2_max_nvindex_buffer(const TPMS_CAPABILITY_DATA *caps);
+
+int
+tpm2_create_salt_key(ESYS_CONTEXT *esys_ctx, const TPMS_CAPABILITY_DATA *algorithms,
+                     ESYS_TR *salt_key);
+
+int
+tpm2_start_auth_session(ESYS_CONTEXT *esys_ctx, ESYS_TR salt_key, ESYS_TR *session);
+
+void
+tpm2_end_auth_session(ESYS_CONTEXT *esys_ctx, ESYS_TR *session);
 
 typedef const OSSL_DISPATCH *(tpm2_dispatch_t)(const TPM2_CAPABILITY *);
 


### PR DESCRIPTION
Auth sessions are used to protect sensitive data (e.g. key passwords / parameters) transferred between the TPM and the provider.

**Salt key**
The approach was to generate a salt key in the null hierarchy. The key is being loaded when the provider is being initialized and destroyed when the provider is being tear down.

The flow is as follows
1. Generates a random salt
2. Encrypts it with the tpmKey's public key (asymmetric encryption — only the TPM can decrypt it)
3. Sends the encrypted salt to the TPM during StartAuthSession
4. Both sides derive the session key from this shared salt
This salt contributes entropy to the session key, which is then used as the symmetric key for AES-CFB parameter encryption/decryption. Without it, there's nothing to encrypt parameters with.

**Session lifetime**
Sessions are being created per operation. If an operation leads to multiple ESYS-API commands, the same session is being reused. This should lead to a good balance between performance and ease of use. In order to start and end the session I added helper functions to tpm2-provider-core.c

**Affected commands**
I modified all commands which used TR_PASSWORD as session handle in order to use an auth session.

**Testing**
Regarding the current testing infrastructure, writing unit tests is difficult. This isn't anything which can be tested explicitly when using openssl cli. We'd need to mock the ESYS-API to verify if the corresponding methods are called.

**Hint**
I developed the idea as well as the implementation with the help of GitHub CoPilot and the Claude Opus 4.6 model. I did a manual review of the code (as well as I can do it) and did some manual adjustments. It compiles and it seems to work. I'm  open to inputs regarding improvements.

Resolves: https://github.com/tpm2-software/tpm2-openssl/issues/65