### PR TITLE
tpm2-provider-digest: clean up digest memory and TPM sessions

### DIFF
--- a/src/tpm2-provider-digest.c
+++ b/src/tpm2-provider-digest.c
@@ -221,7 +221,7 @@ tpm2_digest_freectx(void *ctx)
         return;
 
     tpm2_hash_sequence_flush((TPM2_HASH_SEQUENCE *)dctx);
-    free(dctx->digest);
+    Esys_Free(dctx->digest);
     OPENSSL_clear_free(dctx, sizeof(TPM2_DIGEST_CTX));
 }
 
@@ -302,13 +302,15 @@ tpm2_digest_digest_int(void *provctx, TPM2_ALG_ID algin, const unsigned char *in
     *outl = digest->size;
     if (out != NULL) {
         if (*outl > outsz)
-            return 0;
+            goto error;
         memcpy(out, digest->buffer, *outl);
     }
-
+    Esys_Free(digest);
+    OPENSSL_clear_free(hctx, sizeof(TPM2_HASH_SEQUENCE));
     return 1;
 error:
-    free(digest);
+    tpm2_hash_sequence_flush(hctx);
+    Esys_Free(digest);
     OPENSSL_clear_free(hctx, sizeof(TPM2_HASH_SEQUENCE));
     return 0;
 }

--- a/src/tpm2-provider-digest.c
+++ b/src/tpm2-provider-digest.c
@@ -23,8 +23,10 @@ tpm2_hash_sequence_init(TPM2_HASH_SEQUENCE *seq,
 void
 tpm2_hash_sequence_flush(TPM2_HASH_SEQUENCE *seq)
 {
-    if (seq->handle != ESYS_TR_NONE)
+    if (seq->handle != ESYS_TR_NONE) {
         tpm2_esys_flush_context(seq->esys_lock, seq->esys_ctx, seq->handle);
+        seq->handle = ESYS_TR_NONE;
+    }
 }
 
 int
@@ -249,6 +251,11 @@ tpm2_digest_init(void *ctx, const OSSL_PARAM params[])
     TPM2_DIGEST_CTX *dctx = ctx;
 
     DBG("DIGEST INIT\n");
+
+    tpm2_hash_sequence_flush((TPM2_HASH_SEQUENCE *)dctx);
+    Esys_Free(dctx->digest);
+    dctx->digest = NULL;
+
     return tpm2_hash_sequence_start((TPM2_HASH_SEQUENCE *)dctx);
 }
 


### PR DESCRIPTION
This PR fixes digest cleanup issues in `tpm2-provider-digest.c`.

The `tpm2_digest_digest_int()` function leaked the temporary digest result and hash sequence context on the success path, and also leaked them when the caller's output buffer was too small. In addition, the digest result was allocated by ESAPI but freed by `free()`, not `Esys_Free()`.

The stateful digest path (`tpm2_digest_*()`) also kept the completed digest cached in `dctx->digest` after `final()`. Since `init()` did not clear that cached value, reusing the same digest context could return the previous digest without completing the newly initialized TPM hash sequence.

To resolve those issues, this PR made the necessary changes:

- Ensure to free `digest` and `hctx` in any paths (`tpm2_digest_digest_int()`)
- Flush live TPM hash sequences on cleanup paths
- Use `Esys_Free()` instead of `free()` (`tpm2_digest_freectx()` and `tpm2_digest_digest_int()`)
- Clear cached digest state before starting a new stateful digest operation (`tpm2_digest_init()`)
- Reset flushed sequence handles to be `ESYS_TR_NONE` to avoid repeated flushes of the same handle (`tpm2_hash_sequence_flush()`)