### PR TITLE
tpm2-provider-store-handle: fix memory leak in Esys_TR_Deserialize failure path

### DIFF
--- a/src/tpm2-provider-store-handle.c
+++ b/src/tpm2-provider-store-handle.c
@@ -339,9 +339,9 @@ tpm2_handle_load(void *ctx,
         /* read object metadata */
         r = Esys_TR_Deserialize(sctx->esys_ctx, buffer, buffer_size, &object);
         if (!r) {
-            OPENSSL_free(buffer);
             r = Esys_TR_GetTpmHandle(sctx->esys_ctx, object, &sctx->handle);
         }
+        OPENSSL_free(buffer);
     } else {
         if (!tpm2_semaphore_lock(sctx->esys_lock))
             return 0;


### PR DESCRIPTION
`tpm2_handle_load()` reads serialized object metadata into a temporary buffer before calling `Esys_TR_Deserialize()`. The buffer was only released when deserialization succeeded. To avoid memory leak, this PR moves `OPENSSL_free(buffer)` outside the success-only branch.