### PR TITLE
tpm2-provider-asymcipher,types: add missing NULL checks

### DIFF
--- a/src/tpm2-provider-asymcipher-rsa.c
+++ b/src/tpm2-provider-asymcipher-rsa.c
@@ -154,6 +154,8 @@ rsa_asymcipher_set_ctx_params(void *ctx, const OSSL_PARAM params[])
                 return 0;
             break;
         case OSSL_PARAM_UTF8_STRING:
+            if (p->data == NULL)
+                return 0;
             if (!strcasecmp(p->data, OSSL_PKEY_RSA_PAD_MODE_PKCSV15))
                 actx->decrypt.scheme = TPM2_ALG_RSAES;
             else if (!strcasecmp(p->data, OSSL_PKEY_RSA_PAD_MODE_OAEP))

--- a/src/tpm2-provider-types.c
+++ b/src/tpm2-provider-types.c
@@ -271,6 +271,7 @@ int
 tpm2_param_get_DIGEST(const OSSL_PARAM *p, TPM2B_DIGEST *digest)
 {
     if (p->data_type != OSSL_PARAM_UTF8_STRING
+            || p->data == NULL
             || p->data_size > sizeof(TPMU_HA))
         return 0;
 


### PR DESCRIPTION
Adds the following NULL checks to prevent NULL deref:

- `rsa_asymcipher_set_ctx_params()`: `p->data` before `strcasecmp()` in `OSSL_PARAM_UTF8_STRING` case
- `tpm2_param_get_DIGEST()`: `p->data` before `memcpy()`

The `const OSSL_PARAM *p` pointer is returned by `OSSL_PARAM_locate_const()`. Even if `p` is non-NULL, `p->data` may be `NULL`.