### PR TITLE
fix(pkey): use correct value for true

### DIFF
--- a/src/tpm2-provider-pkey.c
+++ b/src/tpm2-provider-pkey.c
@@ -76,7 +76,7 @@ tpm2_keydata_write(const TPM2_KEYDATA *keydata, BIO *bout, TPM2_PKEY_FORMAT form
     if (!tpk->type)
         goto error;
 
-    tpk->emptyAuth = ! !keydata->emptyAuth;
+    tpk->emptyAuth = keydata->emptyAuth ? 0xFF : 0;
 
     // note the ASN1_INTEGER_set is not reliable for uin32_t on 32-bit machines
     if (!(bn_parent = BN_new()))


### PR DESCRIPTION
ASN1 DER encoding expects the boolean value for true to be 0xFF.
Stricter DER decoders will raise an error if the value isn't 0 or 0xFF.